### PR TITLE
Add English and Russian translations for Multi Wishlist add-on

### DIFF
--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -1,0 +1,32 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: mwl_xlsx\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgctxt "Addons::name::mwl_xlsx"
+msgid "Multi Wishlist"
+msgstr "Multi Wishlist"
+
+msgctxt "Addons::description::mwl_xlsx"
+msgid "Create and manage multiple wishlists."
+msgstr "Create and manage multiple wishlists."
+
+msgctxt "Languages::mwl_xlsx.my_lists"
+msgid "My wishlists"
+msgstr "My wishlists"
+
+msgctxt "Languages::mwl_xlsx.new_list"
+msgid "New list…"
+msgstr "New list…"
+
+msgctxt "Languages::mwl_xlsx.enter_list_name"
+msgid "Enter list name"
+msgstr "Enter list name"
+
+msgctxt "Languages::mwl_xlsx.added"
+msgid "Added to wishlist"
+msgstr "Added to wishlist"
+

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -1,0 +1,32 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: mwl_xlsx\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgctxt "Addons::name::mwl_xlsx"
+msgid "Multi Wishlist"
+msgstr "Несколько списков желаний"
+
+msgctxt "Addons::description::mwl_xlsx"
+msgid "Create and manage multiple wishlists."
+msgstr "Создание и управление несколькими списками желаний."
+
+msgctxt "Languages::mwl_xlsx.my_lists"
+msgid "My wishlists"
+msgstr "Мои списки желаний"
+
+msgctxt "Languages::mwl_xlsx.new_list"
+msgid "New list…"
+msgstr "Новый список…"
+
+msgctxt "Languages::mwl_xlsx.enter_list_name"
+msgid "Enter list name"
+msgstr "Введите название списка"
+
+msgctxt "Languages::mwl_xlsx.added"
+msgid "Added to wishlist"
+msgstr "Добавлено в список желаний"
+


### PR DESCRIPTION
## Summary
- add English .po translation file for Multi Wishlist strings
- add Russian .po translation file for Multi Wishlist strings

## Testing
- `php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`
- `php -l app/addons/mwl_xlsx/func.php`


------
https://chatgpt.com/codex/tasks/task_e_689b52b1f828832cb8d901dbb2686d7f