### PR TITLE
Add wishlist page and dropdown integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 - Create and name wishlists for the current user or session.
 - Add individual products to a chosen wishlist from product listings.
 - View existing wishlists on the **My wishlists** page.
+- Each wishlist shows the number of products and links to its own page.
+- View products of a wishlist on a dedicated page.
 
 ### Add-on URLs
 - `index.php?dispatch=mwl_xlsx.manage` – list user wishlists.

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -12,6 +12,22 @@ if ($mode === 'manage') {
     Tygh::$app['view']->assign('lists', $lists);
 }
 
+if ($mode === 'list') {
+    $list_id = (int) $_REQUEST['list_id'];
+    if (!empty($auth['user_id'])) {
+        $list = db_get_row("SELECT * FROM ?:mwl_xlsx_lists WHERE list_id = ?i AND user_id = ?i", $list_id, $auth['user_id']);
+    } else {
+        $list = db_get_row("SELECT * FROM ?:mwl_xlsx_lists WHERE list_id = ?i AND session_id = ?s", $list_id, Tygh::$app['session']->getID());
+    }
+    if ($list) {
+        $products = fn_mwl_xlsx_get_list_products($list_id);
+        Tygh::$app['view']->assign('list', $list);
+        Tygh::$app['view']->assign('products', $products);
+    } else {
+        return [CONTROLLER_STATUS_NO_PAGE];
+    }
+}
+
 if ($mode === 'create_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = [
         'user_id'    => $auth['user_id'] ?? 0,

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -10,10 +10,45 @@ function fn_mwl_xlsx_get_lists($user_id = null, $session_id = null)
         $session_id = Tygh::$app['session']->getID();
     }
 
+    $condition = $user_id ? ['user_id' => $user_id] : ['session_id' => $session_id];
+
     return db_get_array(
-        "SELECT * FROM ?:mwl_xlsx_lists WHERE ?w ORDER BY created_at ASC",
-        $user_id ? ['user_id' => $user_id] : ['session_id' => $session_id]
+        "SELECT l.*, COUNT(lp.product_id) as products_count"
+        . " FROM ?:mwl_xlsx_lists as l"
+        . " LEFT JOIN ?:mwl_xlsx_list_products as lp ON lp.list_id = l.list_id"
+        . " WHERE ?w GROUP BY l.list_id ORDER BY l.created_at ASC",
+        $condition
     );
+}
+
+function fn_mwl_xlsx_get_list_products($list_id)
+{
+    $items = db_get_hash_array(
+        "SELECT product_id, product_options, amount FROM ?:mwl_xlsx_list_products WHERE list_id = ?i",
+        'product_id',
+        $list_id
+    );
+    if (!$items) {
+        return [];
+    }
+
+    $params = [
+        'pid' => array_keys($items),
+        'extend' => ['description', 'images']
+    ];
+    list($products) = fn_get_products($params);
+    fn_gather_additional_products_data($products, [
+        'get_icon' => true,
+        'get_detailed' => true,
+        'get_options' => true,
+    ]);
+
+    foreach ($products as $product_id => &$product) {
+        $product['selected_options'] = empty($items[$product_id]['product_options']) ? [] : @unserialize($items[$product_id]['product_options']);
+        $product['amount'] = $items[$product_id]['amount'];
+    }
+
+    return $products;
 }
 
 function fn_mwl_xlsx_add($list_id, $product_id, $options = [], $amount = 1)

--- a/js/addons/mwl_xlsx/mwl_xlsx.js
+++ b/js/addons/mwl_xlsx/mwl_xlsx.js
@@ -1,15 +1,28 @@
 (function(_, $) {
+    $(document).on('change', '[data-ca-list-select-xlsx]', function() {
+        var $input = $('[data-ca-mwl-new-list-name]');
+        if ($(this).val() === '_new') {
+            $input.show().focus();
+        } else {
+            $input.hide();
+        }
+    });
+
     $(document).on('click', '[data-ca-add-to-mwl_xlsx]', function() {
         var product_id = $(this).data('caProductId');
-        var list_id = $('[data-ca-list-select-xlsx]').val();
+        var $select = $('[data-ca-list-select-xlsx]');
+        var list_id = $select.val();
         if (list_id === '_new') {
-            var name = prompt(_.tr('mwl_xlsx.enter_list_name'));
+            var name = $('[data-ca-mwl-new-list-name]').val();
             if (name) {
                 $.ceAjax('request', fn_url('mwl_xlsx.create_list'), {
                     method: 'post',
                     data: { name: name },
                     callback: function(data) {
                         list_id = data.list_id;
+                        $select.prepend($('<option>', { value: list_id, text: data.name }));
+                        $select.val(list_id);
+                        $('[data-ca-mwl-new-list-name]').val('').hide();
                         addToList(product_id, list_id);
                     }
                 });
@@ -25,7 +38,13 @@
             method: 'post',
             data: { product_id: product_id, list_id: list_id },
             callback: function() {
-                alert(_.tr('mwl_xlsx.added'));
+                $.ceNotification('show', {
+                    type: 'N',
+                    title: '',
+                    message: _.tr('mwl_xlsx.added'),
+                    message_state: 'I',
+                    overlay: true
+                });
             }
         });
     }

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -28,3 +28,7 @@ msgctxt "Languages::mwl_xlsx.added"
 msgid "Added to wishlist"
 msgstr "Added to wishlist"
 
+msgctxt "Languages::mwl_xlsx.empty_list"
+msgid "Wishlist is empty"
+msgstr "Wishlist is empty"
+

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -30,3 +30,7 @@ msgctxt "Languages::mwl_xlsx.added"
 msgid "Added to wishlist"
 msgstr "Добавлено в список желаний"
 
+msgctxt "Languages::mwl_xlsx.empty_list"
+msgid "Wishlist is empty"
+msgstr "Список пуст"
+

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
@@ -11,6 +11,7 @@
         {/foreach}
         <option value="_new">+ {__("mwl_xlsx.new_list")}</option>
     </select>
+    <input type="text" class="mwl_xlsx-new-name ty-input-text" data-ca-mwl-new-list-name style="display:none" placeholder="{__("mwl_xlsx.enter_list_name")}">
     <button class="ty-btn" data-ca-add-to-mwl_xlsx data-ca-product-id="{$product.product_id}">
         {__("add_to_wishlist")}
     </button>

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/list.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/list.tpl
@@ -1,0 +1,6 @@
+<h1>{$list.name}</h1>
+{if $products}
+    {include file="common/products.tpl" products=$products layout="products_without_options"}
+{else}
+    <p>{__("mwl_xlsx.empty_list")}</p>
+{/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
@@ -1,6 +1,6 @@
 <h1>{__("mwl_xlsx.my_lists")}</h1>
 <ul>
 {foreach $lists as $l}
-    <li>{$l.name}</li>
+    <li><a href="{fn_url("mwl_xlsx.list?list_id=`$l.list_id`")}">{$l.name}</a> ({$l.products_count})</li>
 {/foreach}
 </ul>

--- a/var/themes_repository/bright_theme/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
+++ b/var/themes_repository/bright_theme/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
@@ -11,6 +11,7 @@
         {/foreach}
         <option value="_new">+ {__("mwl_xlsx.new_list")}</option>
     </select>
+    <input type="text" class="mwl_xlsx-new-name ty-input-text" data-ca-mwl-new-list-name style="display:none" placeholder="{__("mwl_xlsx.enter_list_name")}">
     <button class="ty-btn" data-ca-add-to-mwl_xlsx data-ca-product-id="{$product.product_id}">
         {__("add_to_wishlist")}
     </button>

--- a/var/themes_repository/bright_theme/templates/addons/mwl_xlsx/views/mwl_xlsx/list.tpl
+++ b/var/themes_repository/bright_theme/templates/addons/mwl_xlsx/views/mwl_xlsx/list.tpl
@@ -1,0 +1,6 @@
+<h1>{$list.name}</h1>
+{if $products}
+    {include file="common/products.tpl" products=$products}
+{else}
+    <p>{__("mwl_xlsx.empty_list")}</p>
+{/if}

--- a/var/themes_repository/bright_theme/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
+++ b/var/themes_repository/bright_theme/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
@@ -1,6 +1,6 @@
 <h1>{__("mwl_xlsx.my_lists")}</h1>
 <ul>
 {foreach $lists as $l}
-    <li>{$l.name}</li>
+    <li><a href="{fn_url("mwl_xlsx.list?list_id=`$l.list_id`")}">{$l.name}</a> ({$l.products_count})</li>
 {/foreach}
 </ul>


### PR DESCRIPTION
## Summary
- Rename Unitheme hook template and enhance wishlist dropdown
- Show product counts and links on wishlist management
- Add wishlist page with products using Unitheme layout

## Testing
- `php -l app/addons/mwl_xlsx/func.php app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`

------
https://chatgpt.com/codex/tasks/task_e_689baac55b88832cafad6bcbd80c2dae