### PR TITLE
Add breadcrumbs and titles for wishlist pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Each wishlist shows the number of products and links to its own page.
 - View products of a wishlist on a dedicated page.
 - Export wishlists to XLSX files from the wishlist list page, placing each product feature in its own column and translating product and feature data into the site's current language.
+- Navigate wishlists with breadcrumbs and page titles.
 
 ### Add-on URLs
 - `index.php?dispatch=mwl_xlsx.manage` – list user wishlists.

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -55,6 +55,7 @@
             <values>
                 <value id="mwl_xlsx.name">Multi Wishlist</value>
                 <value id="mwl_xlsx.description">Create and manage multiple wishlists.</value>
+                <value id="mwl_xlsx.wishlists">Wishlists</value>
                 <value id="mwl_xlsx.my_lists">My wishlists</value>
                 <value id="mwl_xlsx.new_list">New list…</value>
                 <value id="mwl_xlsx.enter_list_name">Enter list name</value>
@@ -66,6 +67,7 @@
             <values>
                 <value id="mwl_xlsx.name">Несколько списков желаний</value>
                 <value id="mwl_xlsx.description">Создание и управление несколькими списками желаний.</value>
+                <value id="mwl_xlsx.wishlists">Списки желаний</value>
                 <value id="mwl_xlsx.my_lists">Мои списки желаний</value>
                 <value id="mwl_xlsx.new_list">Новый список…</value>
                 <value id="mwl_xlsx.enter_list_name">Введите название списка</value>

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -9,6 +9,11 @@ if ($mode === 'manage') {
         $lists = fn_mwl_xlsx_get_lists(null, Tygh::$app['session']->getID());
     }
     Tygh::$app['view']->assign('lists', $lists);
+    Tygh::$app['view']->assign('page_title', __('mwl_xlsx.my_lists'));
+    Tygh::$app['view']->assign('breadcrumbs', [
+        ['title' => __('home'), 'link' => fn_url('')],
+        ['title' => __('mwl_xlsx.wishlists')]
+    ]);
 }
 
 if ($mode === 'list') {
@@ -22,6 +27,12 @@ if ($mode === 'list') {
         $products = fn_mwl_xlsx_get_list_products($list_id, CART_LANGUAGE);
         Tygh::$app['view']->assign('list', $list);
         Tygh::$app['view']->assign('products', $products);
+        Tygh::$app['view']->assign('page_title', $list['name']);
+        Tygh::$app['view']->assign('breadcrumbs', [
+            ['title' => __('home'), 'link' => fn_url('')],
+            ['title' => __('mwl_xlsx.wishlists'), 'link' => fn_url('mwl_xlsx.manage')],
+            ['title' => $list['name']]
+        ]);
     } else {
         return [CONTROLLER_STATUS_NO_PAGE];
     }

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -16,6 +16,10 @@ msgctxt "Languages::mwl_xlsx.my_lists"
 msgid "My wishlists"
 msgstr "My wishlists"
 
+msgctxt "Languages::mwl_xlsx.wishlists"
+msgid "Wishlists"
+msgstr "Wishlists"
+
 msgctxt "Languages::mwl_xlsx.new_list"
 msgid "New list…"
 msgstr "New list…"

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -18,6 +18,10 @@ msgctxt "Languages::mwl_xlsx.my_lists"
 msgid "My wishlists"
 msgstr "Мои списки желаний"
 
+msgctxt "Languages::mwl_xlsx.wishlists"
+msgid "Wishlists"
+msgstr "Списки желаний"
+
 msgctxt "Languages::mwl_xlsx.new_list"
 msgid "New list…"
 msgstr "Новый список…"


### PR DESCRIPTION
## Summary
- Add breadcrumb navigation and page titles for wishlist listing and detail pages
- Provide language strings for "Wishlists" in English and Russian
- Document breadcrumb navigation in README

## Testing
- `php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`


------
https://chatgpt.com/codex/tasks/task_e_689c743790c8832c9334d8548834596a