### PR TITLE
Add rename and delete actions for wishlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@
 - View products of a wishlist on a dedicated page.
 - Export wishlists to XLSX files from the wishlist list page, placing each product feature in its own column and translating product and feature data into the site's current language.
 - Navigate wishlists with breadcrumbs and page titles.
+- Rename or remove wishlists from the manage page.
 
 ### Add-on URLs
 - `index.php?dispatch=mwl_xlsx.manage` – list user wishlists.
 - `index.php?dispatch=mwl_xlsx.create_list` – create a wishlist (POST).
 - `index.php?dispatch=mwl_xlsx.add` – add a product to a wishlist (POST).
+- `index.php?dispatch=mwl_xlsx.rename_list` – rename a wishlist (POST).
+- `index.php?dispatch=mwl_xlsx.delete_list` – remove a wishlist (POST).
 
 ### TODO
 - [ ] Add all selected products to a wishlist (default limit: 20 items).

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -60,6 +60,9 @@
                 <value id="mwl_xlsx.new_list">New list…</value>
                 <value id="mwl_xlsx.enter_list_name">Enter list name</value>
                 <value id="mwl_xlsx.added">Added to wishlist</value>
+                <value id="mwl_xlsx.rename">Rename</value>
+                <value id="mwl_xlsx.remove">Remove</value>
+                <value id="mwl_xlsx.confirm_remove">Remove this list?</value>
             </values>
         </item>
         <item>
@@ -72,6 +75,9 @@
                 <value id="mwl_xlsx.new_list">Новый список…</value>
                 <value id="mwl_xlsx.enter_list_name">Введите название списка</value>
                 <value id="mwl_xlsx.added">Добавлено в список желаний</value>
+                <value id="mwl_xlsx.rename">Переименовать</value>
+                <value id="mwl_xlsx.remove">Удалить</value>
+                <value id="mwl_xlsx.confirm_remove">Удалить этот список?</value>
             </values>
         </item>
     </languages>

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -98,6 +98,21 @@ if ($mode === 'create_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     exit(json_encode(['list_id' => $list_id, 'name' => $data['name']]));
 }
 
+if ($mode === 'rename_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user_id = $auth['user_id'] ?? null;
+    $session_id = $user_id ? null : Tygh::$app['session']->getID();
+    $name = trim((string) $_REQUEST['name']);
+    $updated = $name === '' ? false : fn_mwl_xlsx_update_list_name((int) $_REQUEST['list_id'], $name, $user_id, $session_id);
+    exit(json_encode(['success' => $updated, 'name' => $name]));
+}
+
+if ($mode === 'delete_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user_id = $auth['user_id'] ?? null;
+    $session_id = $user_id ? null : Tygh::$app['session']->getID();
+    $deleted = fn_mwl_xlsx_delete_list((int) $_REQUEST['list_id'], $user_id, $session_id);
+    exit(json_encode(['success' => $deleted]));
+}
+
 if ($mode === 'add' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     $added = fn_mwl_xlsx_add($_REQUEST['list_id'], $_REQUEST['product_id'], $_REQUEST['product_options'] ?? [], 1);
     $message = $added ? __('mwl_xlsx.added') : __('mwl_xlsx.already_exists');

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -126,3 +126,32 @@ function fn_mwl_xlsx_add($list_id, $product_id, $options = [], $amount = 1)
 
     return true;
 }
+
+function fn_mwl_xlsx_update_list_name($list_id, $name, $user_id = null, $session_id = null)
+{
+    if (!$user_id && !$session_id) {
+        $session_id = Tygh::$app['session']->getID();
+    }
+    $condition = $user_id ? ['list_id' => $list_id, 'user_id' => $user_id] : ['list_id' => $list_id, 'session_id' => $session_id];
+    $exists = db_get_field('SELECT list_id FROM ?:mwl_xlsx_lists WHERE ?w', $condition);
+    if ($exists) {
+        db_query('UPDATE ?:mwl_xlsx_lists SET name = ?s WHERE list_id = ?i', $name, $list_id);
+        return true;
+    }
+    return false;
+}
+
+function fn_mwl_xlsx_delete_list($list_id, $user_id = null, $session_id = null)
+{
+    if (!$user_id && !$session_id) {
+        $session_id = Tygh::$app['session']->getID();
+    }
+    $condition = $user_id ? ['list_id' => $list_id, 'user_id' => $user_id] : ['list_id' => $list_id, 'session_id' => $session_id];
+    $exists = db_get_field('SELECT list_id FROM ?:mwl_xlsx_lists WHERE ?w', $condition);
+    if ($exists) {
+        db_query('DELETE FROM ?:mwl_xlsx_lists WHERE list_id = ?i', $list_id);
+        db_query('DELETE FROM ?:mwl_xlsx_list_products WHERE list_id = ?i', $list_id);
+        return true;
+    }
+    return false;
+}

--- a/js/addons/mwl_xlsx/mwl_xlsx.js
+++ b/js/addons/mwl_xlsx/mwl_xlsx.js
@@ -52,12 +52,12 @@
         var list_id = $renameDialog.data('caMwlListId');
         var name = $('#mwl_xlsx_rename_input').val().trim();
         if (name) {
-            $.ceAjax('request', fn_url('mwl_xlsx.rename_list'), {
+                $.ceAjax('request', fn_url('mwl_xlsx.rename_list'), {
                 method: 'post',
                 data: { list_id: list_id, name: name },
                 callback: function(data) {
                     if (data && data.success) {
-                        $('[data-ca-mwl-list-id="' + list_id + '"]').find('[data-ca-mwl-list-name]').text(data.name);
+                        location.reload();
                     }
                 }
             });
@@ -82,18 +82,15 @@
 
     $(document).on('click', '[data-ca-mwl-delete-confirm]', function() {
         var list_id = $deleteDialog.data('caMwlListId');
-        $.ceAjax('request', fn_url('mwl_xlsx.delete_list'), {
-            method: 'post',
-            data: { list_id: list_id },
-            callback: function(data) {
-                if (data && data.success) {
-                    $('[data-ca-mwl-list-id="' + list_id + '"]').remove();
-                    if (!$('[data-ca-mwl-list-id]').length) {
+            $.ceAjax('request', fn_url('mwl_xlsx.delete_list'), {
+                method: 'post',
+                data: { list_id: list_id },
+                callback: function(data) {
+                    if (data && data.success) {
                         location.reload();
                     }
                 }
-            }
-        });
+            });
         $deleteDialog.ceDialog('close');
         return false;
     });

--- a/js/addons/mwl_xlsx/mwl_xlsx.js
+++ b/js/addons/mwl_xlsx/mwl_xlsx.js
@@ -33,42 +33,73 @@
         return false;
     });
 
+    var $renameDialog = $('#mwl_xlsx_rename_dialog');
+    var $deleteDialog = $('#mwl_xlsx_delete_dialog');
+
     $(document).on('click', '[data-ca-mwl-rename]', function() {
         var $li = $(this).closest('[data-ca-mwl-list-id]');
         var list_id = $li.data('caMwlListId');
         var current_name = $li.find('[data-ca-mwl-list-name]').text();
-        var name = prompt(_.tr('mwl_xlsx.enter_list_name') || 'Enter list name', current_name);
-        if (name && name !== current_name) {
+        $renameDialog.data('caMwlListId', list_id);
+        $('#mwl_xlsx_rename_input').val(current_name);
+        $renameDialog.ceDialog('open', {
+            title: _.tr('mwl_xlsx.rename') || 'Rename'
+        });
+        return false;
+    });
+
+    $(document).on('click', '[data-ca-mwl-rename-save]', function() {
+        var list_id = $renameDialog.data('caMwlListId');
+        var name = $('#mwl_xlsx_rename_input').val().trim();
+        if (name) {
             $.ceAjax('request', fn_url('mwl_xlsx.rename_list'), {
                 method: 'post',
                 data: { list_id: list_id, name: name },
                 callback: function(data) {
                     if (data && data.success) {
-                        $li.find('[data-ca-mwl-list-name]').text(data.name);
+                        $('[data-ca-mwl-list-id="' + list_id + '"]').find('[data-ca-mwl-list-name]').text(data.name);
                     }
                 }
             });
         }
+        $renameDialog.ceDialog('close');
+        return false;
+    });
+
+    $(document).on('click', '[data-ca-mwl-rename-cancel]', function() {
+        $renameDialog.ceDialog('close');
         return false;
     });
 
     $(document).on('click', '[data-ca-mwl-delete]', function() {
-        var $li = $(this).closest('[data-ca-mwl-list-id]');
-        var list_id = $li.data('caMwlListId');
-        if (confirm(_.tr('mwl_xlsx.confirm_remove') || 'Remove this list?')) {
-            $.ceAjax('request', fn_url('mwl_xlsx.delete_list'), {
-                method: 'post',
-                data: { list_id: list_id },
-                callback: function(data) {
-                    if (data && data.success) {
-                        $li.remove();
-                        if (!$('[data-ca-mwl-list-id]').length) {
-                            location.reload();
-                        }
+        var list_id = $(this).closest('[data-ca-mwl-list-id]').data('caMwlListId');
+        $deleteDialog.data('caMwlListId', list_id);
+        $deleteDialog.ceDialog('open', {
+            title: _.tr('mwl_xlsx.remove') || 'Remove'
+        });
+        return false;
+    });
+
+    $(document).on('click', '[data-ca-mwl-delete-confirm]', function() {
+        var list_id = $deleteDialog.data('caMwlListId');
+        $.ceAjax('request', fn_url('mwl_xlsx.delete_list'), {
+            method: 'post',
+            data: { list_id: list_id },
+            callback: function(data) {
+                if (data && data.success) {
+                    $('[data-ca-mwl-list-id="' + list_id + '"]').remove();
+                    if (!$('[data-ca-mwl-list-id]').length) {
+                        location.reload();
                     }
                 }
-            });
-        }
+            }
+        });
+        $deleteDialog.ceDialog('close');
+        return false;
+    });
+
+    $(document).on('click', '[data-ca-mwl-delete-cancel]', function() {
+        $deleteDialog.ceDialog('close');
         return false;
     });
 

--- a/js/addons/mwl_xlsx/mwl_xlsx.js
+++ b/js/addons/mwl_xlsx/mwl_xlsx.js
@@ -33,6 +33,45 @@
         return false;
     });
 
+    $(document).on('click', '[data-ca-mwl-rename]', function() {
+        var $li = $(this).closest('[data-ca-mwl-list-id]');
+        var list_id = $li.data('caMwlListId');
+        var current_name = $li.find('[data-ca-mwl-list-name]').text();
+        var name = prompt(_.tr('mwl_xlsx.enter_list_name') || 'Enter list name', current_name);
+        if (name && name !== current_name) {
+            $.ceAjax('request', fn_url('mwl_xlsx.rename_list'), {
+                method: 'post',
+                data: { list_id: list_id, name: name },
+                callback: function(data) {
+                    if (data && data.success) {
+                        $li.find('[data-ca-mwl-list-name]').text(data.name);
+                    }
+                }
+            });
+        }
+        return false;
+    });
+
+    $(document).on('click', '[data-ca-mwl-delete]', function() {
+        var $li = $(this).closest('[data-ca-mwl-list-id]');
+        var list_id = $li.data('caMwlListId');
+        if (confirm(_.tr('mwl_xlsx.confirm_remove') || 'Remove this list?')) {
+            $.ceAjax('request', fn_url('mwl_xlsx.delete_list'), {
+                method: 'post',
+                data: { list_id: list_id },
+                callback: function(data) {
+                    if (data && data.success) {
+                        $li.remove();
+                        if (!$('[data-ca-mwl-list-id]').length) {
+                            location.reload();
+                        }
+                    }
+                }
+            });
+        }
+        return false;
+    });
+
     function addToList(product_id, list_id) {
         $.ceAjax('request', fn_url('mwl_xlsx.add'), {
             method: 'post',

--- a/js/addons/mwl_xlsx/mwl_xlsx.js
+++ b/js/addons/mwl_xlsx/mwl_xlsx.js
@@ -19,6 +19,7 @@
                     method: 'post',
                     data: { name: name },
                     callback: function(data) {
+                        data = parseResponse(data);
                         list_id = data.list_id;
                         $select.prepend($('<option>', { value: list_id, text: data.name }));
                         $select.val(list_id);
@@ -52,10 +53,11 @@
         var list_id = $renameDialog.data('caMwlListId');
         var name = $('#mwl_xlsx_rename_input').val().trim();
         if (name) {
-                $.ceAjax('request', fn_url('mwl_xlsx.rename_list'), {
+            $.ceAjax('request', fn_url('mwl_xlsx.rename_list'), {
                 method: 'post',
                 data: { list_id: list_id, name: name },
                 callback: function(data) {
+                    data = parseResponse(data);
                     if (data && data.success) {
                         location.reload();
                     }
@@ -82,15 +84,16 @@
 
     $(document).on('click', '[data-ca-mwl-delete-confirm]', function() {
         var list_id = $deleteDialog.data('caMwlListId');
-            $.ceAjax('request', fn_url('mwl_xlsx.delete_list'), {
-                method: 'post',
-                data: { list_id: list_id },
-                callback: function(data) {
-                    if (data && data.success) {
-                        location.reload();
-                    }
+        $.ceAjax('request', fn_url('mwl_xlsx.delete_list'), {
+            method: 'post',
+            data: { list_id: list_id },
+            callback: function(data) {
+                data = parseResponse(data);
+                if (data && data.success) {
+                    location.reload();
                 }
-            });
+            }
+        });
         $deleteDialog.ceDialog('close');
         return false;
     });
@@ -105,6 +108,7 @@
             method: 'post',
             data: { product_id: product_id, list_id: list_id },
             callback: function(data) {
+                data = parseResponse(data);
                 var message = (data && data.message) ? data.message : (_.tr('mwl_xlsx.added') || 'Added to wishlist');
                 $.ceNotification('show', {
                     type: 'N',
@@ -115,6 +119,16 @@
                 });
             }
         });
+    }
+
+    function parseResponse(data) {
+        if (data && typeof data.text === 'string') {
+            try {
+                return JSON.parse(data.text);
+            } catch (e) {
+            }
+        }
+        return data || {};
     }
 })(Tygh, Tygh.$);
 

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -44,3 +44,15 @@ msgctxt "Languages::mwl_xlsx.export"
 msgid "Export XLSX"
 msgstr "Export XLSX"
 
+msgctxt "Languages::mwl_xlsx.rename"
+msgid "Rename"
+msgstr "Rename"
+
+msgctxt "Languages::mwl_xlsx.remove"
+msgid "Remove"
+msgstr "Remove"
+
+msgctxt "Languages::mwl_xlsx.confirm_remove"
+msgid "Remove this list?"
+msgstr "Remove this list?"
+

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -46,3 +46,15 @@ msgctxt "Languages::mwl_xlsx.export"
 msgid "Export XLSX"
 msgstr "Экспорт в XLSX"
 
+msgctxt "Languages::mwl_xlsx.rename"
+msgid "Rename"
+msgstr "Переименовать"
+
+msgctxt "Languages::mwl_xlsx.remove"
+msgid "Remove"
+msgstr "Удалить"
+
+msgctxt "Languages::mwl_xlsx.confirm_remove"
+msgid "Remove this list?"
+msgstr "Удалить этот список?"
+

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
@@ -1,11 +1,13 @@
 {capture name="mainbox"}
     {if $lists}
-        <ul>
+        <ul data-ca-mwl-lists>
         {foreach $lists as $l}
-            <li>
-                <a href="{fn_url("mwl_xlsx.list?list_id=`$l.list_id`")}">{$l.name}</a>
+            <li data-ca-mwl-list-id="{$l.list_id}">
+                <a data-ca-mwl-list-name href="{fn_url("mwl_xlsx.list?list_id=`$l.list_id`")}">{$l.name}</a>
                 ({$l.products_count})
                 <a href="{fn_url("mwl_xlsx.export?list_id=`$l.list_id`")}">{__("mwl_xlsx.export")}</a>
+                <a href="#" data-ca-mwl-rename>{__("mwl_xlsx.rename")}</a>
+                <a href="#" data-ca-mwl-delete>{__("mwl_xlsx.remove")}</a>
             </li>
         {/foreach}
         </ul>

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
@@ -6,7 +6,7 @@
                 <a data-ca-mwl-list-name href="{fn_url("mwl_xlsx.list?list_id=`$l.list_id`")}">{$l.name}</a>
                 ({$l.products_count})
                 <a href="{fn_url("mwl_xlsx.export?list_id=`$l.list_id`")}">{__("mwl_xlsx.export")}</a>
-                <a href="#" data-ca-mwl-rename title="{__("mwl_xlsx.rename")}"><i class="ut2-icon-baseline-edit"></i></a>
+                <a href="#" data-ca-mwl-rename title="{__("mwl_xlsx.rename")}"><i class="ut2-icon-more_vert"></i></a>
                 <a href="#" data-ca-mwl-delete title="{__("mwl_xlsx.remove")}"><i class="ut2-icon-baseline-delete"></i></a>
             </li>
         {/foreach}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
@@ -6,8 +6,8 @@
                 <a data-ca-mwl-list-name href="{fn_url("mwl_xlsx.list?list_id=`$l.list_id`")}">{$l.name}</a>
                 ({$l.products_count})
                 <a href="{fn_url("mwl_xlsx.export?list_id=`$l.list_id`")}">{__("mwl_xlsx.export")}</a>
-                <a href="#" data-ca-mwl-rename>{__("mwl_xlsx.rename")}</a>
-                <a href="#" data-ca-mwl-delete>{__("mwl_xlsx.remove")}</a>
+                <a href="#" data-ca-mwl-rename title="{__("mwl_xlsx.rename")}"><i class="ut2-icon-baseline-edit"></i></a>
+                <a href="#" data-ca-mwl-delete title="{__("mwl_xlsx.remove")}"><i class="ut2-icon-baseline-delete"></i></a>
             </li>
         {/foreach}
         </ul>
@@ -15,6 +15,25 @@
         {include file="common/no_items.tpl"}
     {/if}
 {/capture}
+
+<div id="mwl_xlsx_rename_dialog" class="hidden">
+    <div class="ty-control-group">
+        <label for="mwl_xlsx_rename_input" class="ty-control-group__title">{__("mwl_xlsx.enter_list_name")}</label>
+        <input type="text" id="mwl_xlsx_rename_input" class="ty-input-text" />
+    </div>
+    <div class="buttons-container">
+        <button class="ty-btn ty-btn__primary" data-ca-mwl-rename-save>{__("save")}</button>
+        <button class="ty-btn" data-ca-mwl-rename-cancel>{__("cancel")}</button>
+    </div>
+</div>
+
+<div id="mwl_xlsx_delete_dialog" class="hidden">
+    <div class="ty-dialog-body">{__("mwl_xlsx.confirm_remove")}</div>
+    <div class="buttons-container">
+        <button class="ty-btn ty-btn__primary" data-ca-mwl-delete-confirm>{__("mwl_xlsx.remove")}</button>
+        <button class="ty-btn" data-ca-mwl-delete-cancel>{__("cancel")}</button>
+    </div>
+</div>
 
 {include file="blocks/wrappers/mainbox_simple.tpl"
     title=__("mwl_xlsx.my_lists")


### PR DESCRIPTION
## Summary
- allow renaming or deleting wishlists from the manage page
- expose controller modes and JS to support rename and delete
- document new capabilities and endpoints

## Testing
- `php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`
- `php -l app/addons/mwl_xlsx/func.php`
- `node --check js/addons/mwl_xlsx/mwl_xlsx.js`


------
https://chatgpt.com/codex/tasks/task_e_689c79bb0564832c8b1c1c4ca7e9404d