### PR TITLE
Link wishlist in add notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Add individual products to a chosen wishlist from product listings.
 - Remember the last selected wishlist when adding products.
 - Avoid duplicate products when adding to a wishlist.
+- Show a notification with a link to the wishlist after adding a product.
 - View existing wishlists on the **My wishlists** page.
 - Each wishlist shows the number of products and links to its own page.
 - View products of a wishlist on a dedicated page.

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -59,7 +59,8 @@
                 <value id="mwl_xlsx.my_lists">My wishlists</value>
                 <value id="mwl_xlsx.new_list">New list…</value>
                 <value id="mwl_xlsx.enter_list_name">Enter list name</value>
-                <value id="mwl_xlsx.added">Added to wishlist</value>
+                <value id="mwl_xlsx.added"><![CDATA[Added to <a href="[list_url]">[list_name]</a>]]></value>
+                <value id="mwl_xlsx.added_plain">Added to wishlist</value>
                 <value id="mwl_xlsx.rename">Rename</value>
                 <value id="mwl_xlsx.remove">Remove</value>
                 <value id="mwl_xlsx.confirm_remove">Remove this list?</value>
@@ -74,7 +75,8 @@
                 <value id="mwl_xlsx.my_lists">Мои списки желаний</value>
                 <value id="mwl_xlsx.new_list">Новый список…</value>
                 <value id="mwl_xlsx.enter_list_name">Введите название списка</value>
-                <value id="mwl_xlsx.added">Добавлено в список желаний</value>
+                <value id="mwl_xlsx.added"><![CDATA[Добавлено в <a href="[list_url]">[list_name]</a>]]></value>
+                <value id="mwl_xlsx.added_plain">Добавлено в список желаний</value>
                 <value id="mwl_xlsx.rename">Переименовать</value>
                 <value id="mwl_xlsx.remove">Удалить</value>
                 <value id="mwl_xlsx.confirm_remove">Удалить этот список?</value>

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -114,7 +114,18 @@ if ($mode === 'delete_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 if ($mode === 'add' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-    $added = fn_mwl_xlsx_add($_REQUEST['list_id'], $_REQUEST['product_id'], $_REQUEST['product_options'] ?? [], 1);
-    $message = $added ? __('mwl_xlsx.added') : __('mwl_xlsx.already_exists');
+    $list_id = (int) $_REQUEST['list_id'];
+    $added = fn_mwl_xlsx_add($list_id, $_REQUEST['product_id'], $_REQUEST['product_options'] ?? [], 1);
+
+    if ($added) {
+        $list_name = db_get_field('SELECT name FROM ?:mwl_xlsx_lists WHERE list_id = ?i', $list_id);
+        $message = __('mwl_xlsx.added', [
+            '[list_name]' => htmlspecialchars($list_name, ENT_QUOTES, 'UTF-8'),
+            '[list_url]'  => fn_url('mwl_xlsx.list?list_id=' . $list_id)
+        ]);
+    } else {
+        $message = __('mwl_xlsx.already_exists');
+    }
+
     exit(json_encode(['success' => true, 'message' => $message]));
 }

--- a/js/addons/mwl_xlsx/mwl_xlsx.js
+++ b/js/addons/mwl_xlsx/mwl_xlsx.js
@@ -123,7 +123,7 @@
             data: { product_id: product_id, list_id: list_id },
             callback: function(data) {
                 data = parseResponse(data);
-                var message = (data && data.message) ? data.message : (_.tr('mwl_xlsx.added') || 'Added to wishlist');
+                var message = (data && data.message) ? data.message : (_.tr('mwl_xlsx.added_plain') || 'Added to wishlist');
                 $.ceNotification('show', {
                     type: 'N',
                     title: '',

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -29,6 +29,10 @@ msgid "Enter list name"
 msgstr "Enter list name"
 
 msgctxt "Languages::mwl_xlsx.added"
+msgid "Added to <a href=\"[list_url]\">[list_name]</a>"
+msgstr "Added to <a href=\"[list_url]\">[list_name]</a>"
+
+msgctxt "Languages::mwl_xlsx.added_plain"
 msgid "Added to wishlist"
 msgstr "Added to wishlist"
 

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -31,6 +31,10 @@ msgid "Enter list name"
 msgstr "Введите название списка"
 
 msgctxt "Languages::mwl_xlsx.added"
+msgid "Added to <a href=\"[list_url]\">[list_name]</a>"
+msgstr "Добавлено в <a href=\"[list_url]\">[list_name]</a>"
+
+msgctxt "Languages::mwl_xlsx.added_plain"
 msgid "Added to wishlist"
 msgstr "Добавлено в список желаний"
 


### PR DESCRIPTION
## Summary
- Show a notification linking to the wishlist after adding a product
- Localize messages with HTML links
- Document new notification behavior

## Testing
- `php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`
- `node --check js/addons/mwl_xlsx/mwl_xlsx.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9b2f4bb4832c852a857f5c96da95