### PR TITLE
Add SEO-friendly URLs for media lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@
 - Export wishlists to XLSX files from the wishlist list page, placing each product feature in its own column and translating product and feature data into the site's current language.
 - Navigate wishlists with breadcrumbs and page titles.
 - Rename or remove wishlists from the manage page.
+- SEO-friendly URLs for wishlist pages (`/media-lists` and `/media-lists/{list_id}`).
 
 ### Add-on URLs
+- `/media-lists` – list user wishlists.
+- `/media-lists/{list_id}` – view a wishlist.
 - `index.php?dispatch=mwl_xlsx.manage` – list user wishlists.
+- `index.php?dispatch=mwl_xlsx.view&list_id={list_id}` – view a wishlist.
 - `index.php?dispatch=mwl_xlsx.create_list` – create a wishlist (POST).
 - `index.php?dispatch=mwl_xlsx.add` – add a product to a wishlist (POST).
 - `index.php?dispatch=mwl_xlsx.rename_list` – rename a wishlist (POST).

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -1,6 +1,7 @@
 <?php
 
 if (!defined('BOOTSTRAP')) { die('Access denied'); }
+use Tygh\Registry;
 
 if ($mode === 'manage') {
     if (!empty($auth['user_id'])) {
@@ -16,7 +17,7 @@ if ($mode === 'manage') {
     ]);
 }
 
-if ($mode === 'list') {
+if ($mode === 'list' || $mode === 'view') {
     $list_id = (int) $_REQUEST['list_id'];
     if (!empty($auth['user_id'])) {
         $list = db_get_row("SELECT * FROM ?:mwl_xlsx_lists WHERE list_id = ?i AND user_id = ?i", $list_id, $auth['user_id']);
@@ -121,7 +122,7 @@ if ($mode === 'add' && $_SERVER['REQUEST_METHOD'] === 'POST') {
         $list_name = db_get_field('SELECT name FROM ?:mwl_xlsx_lists WHERE list_id = ?i', $list_id);
         $message = __('mwl_xlsx.added', [
             '[list_name]' => htmlspecialchars($list_name, ENT_QUOTES, 'UTF-8'),
-            '[list_url]'  => fn_url('mwl_xlsx.list?list_id=' . $list_id)
+            '[list_url]'  => fn_url(fn_mwl_xlsx_url($list_id))
         ]);
     } else {
         $message = __('mwl_xlsx.already_exists');
@@ -140,7 +141,7 @@ if ($mode === 'add_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     $list_name = db_get_field('SELECT name FROM ?:mwl_xlsx_lists WHERE list_id = ?i', $list_id);
     $message = __('mwl_xlsx.added', [
         '[list_name]' => htmlspecialchars($list_name, ENT_QUOTES, 'UTF-8'),
-        '[list_url]'  => fn_url('mwl_xlsx.list?list_id=' . $list_id)
+        '[list_url]'  => fn_url(fn_mwl_xlsx_url($list_id))
     ]);
 
     exit(json_encode(['success' => true, 'message' => $message]));

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -3,6 +3,12 @@ use Tygh\Registry;
 
 if (!defined('BOOTSTRAP')) { die('Access denied'); }
 
+function fn_mwl_xlsx_url($list_id)
+{
+    $list_id = (int) $list_id;
+    return "media-lists/{$list_id}";
+}
+
 function fn_mwl_xlsx_get_lists($user_id = null, $session_id = null)
 {
     // If user is not authorized and session_id wasn't provided, use current session id

--- a/app/addons/mwl_xlsx/init.php
+++ b/app/addons/mwl_xlsx/init.php
@@ -3,5 +3,22 @@ if (!defined('BOOTSTRAP')) { die('Access denied'); }
 
 fn_register_hooks(
     'auth_routines_post',
-    'init_user_session_data_post'
+    'init_user_session_data_post',
+    'before_dispatch'
 );
+
+function fn_mwl_xlsx_before_dispatch(&$controller, &$mode, &$action, &$dispatch_extra, &$area)
+{
+    $path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+    if (!$path) {
+        return;
+    }
+
+    if (preg_match('~/(?:[a-z]{2}/)?media-lists/(\d+)/?$~i', $path, $m)) {
+        $_REQUEST['dispatch'] = 'mwl_xlsx.view';
+        $_REQUEST['list_id']  = (int) $m[1];
+
+        $controller = 'mwl_xlsx';
+        $mode       = 'view';
+    }
+}

--- a/app/addons/mwl_xlsx/schemas/seo/objects.post.php
+++ b/app/addons/mwl_xlsx/schemas/seo/objects.post.php
@@ -1,0 +1,8 @@
+<?php
+$schema = $schema ?? [];
+
+$schema['/media-lists'] = [
+    'dispatch' => 'mwl_xlsx.manage',
+];
+
+return $schema;

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
@@ -3,7 +3,7 @@
         <ul data-ca-mwl-lists>
         {foreach $lists as $l}
             <li data-ca-mwl-list-id="{$l.list_id}">
-                <a data-ca-mwl-list-name href="{fn_url("mwl_xlsx.list?list_id=`$l.list_id`")}">{$l.name}</a>
+                <a data-ca-mwl-list-name href="{$l.list_id|fn_mwl_xlsx_url|fn_url}">{$l.name}</a>
                 ({$l.products_count})
                 <a class="mwl_xlsx-export" href="{fn_url("mwl_xlsx.export?list_id=`$l.list_id`")}" title="{__("mwl_xlsx.export")}"><img src="{$images_dir}/addons/mwl_xlsx/xlsx.svg" alt="{__("mwl_xlsx.export")}" width="20" height="20" /></a>
                 <a href="#" data-ca-mwl-rename title="{__("mwl_xlsx.rename")}"><i class="ut2-icon-more_vert"></i></a>

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
@@ -1,0 +1,17 @@
+{capture name="mainbox"}
+    {if $products}
+        {include file="blocks/list_templates/products_list.tpl"
+            products=$products
+            layout="products_without_options"
+            no_pagination=true
+            item_number=0
+        }
+    {else}
+        {include file="common/no_items.tpl" text=__("mwl_xlsx.empty_list")}
+    {/if}
+{/capture}
+
+{include file="blocks/wrappers/mainbox_general.tpl"
+    title=$list.name
+    content=$smarty.capture.mainbox
+}


### PR DESCRIPTION
## Summary
- add SEO schema and hook to serve /media-lists and /media-lists/{list_id}
- expose helper and view mode to generate SEO wishlist links
- document SEO URLs in README

## Testing
- `php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`
- `php -l app/addons/mwl_xlsx/init.php`
- `php -l app/addons/mwl_xlsx/func.php`
- `php -l app/addons/mwl_xlsx/schemas/seo/objects.post.php`


------
https://chatgpt.com/codex/tasks/task_e_689caea8e2ec832ca04bac2cac6a72d5