### PR TITLE
Add admin page for XLSX templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Each wishlist shows the number of products and links to its own page.
 - View products of a wishlist on a dedicated page.
 - Export wishlists to XLSX files from the wishlist list page, placing each product feature in its own column and translating product and feature data into the site's current language.
+- Manage XLSX templates from the admin panel for custom export layouts.
 - Navigate wishlists with breadcrumbs and page titles.
 - Rename or remove wishlists from the manage page.
 - SEO-friendly URLs for wishlist pages (`/media-lists` and `/media-lists/{list_id}`).
@@ -27,7 +28,6 @@
 
 ### TODO
 - [ ] Export wishlist to XLSX on a single wishlist page.
-- [ ] Upload XLSX template for a wishlist.
 
 ### Dev install
 

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -12,6 +12,8 @@
     <name>Multi Wishlist</name>
     <description>Adds multiple wishlists per user without core changes (hooks, own tables, UI on product buttons).</description>
 
+    <uninstall>fn_mwl_xlsx_uninstall</uninstall>
+
     <!-- Установочные/деинсталляционные SQL -->
     <queries>
         <!-- install -->
@@ -35,6 +37,20 @@
         `timestamp` INT NOT NULL,
         PRIMARY KEY (`list_id`, `product_id`, `timestamp`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+        ]]></item>
+
+        <item for="install"><![CDATA[
+        CREATE TABLE IF NOT EXISTS `?:mwl_xlsx_templates` (
+        `template_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+        `company_id` INT UNSIGNED NOT NULL DEFAULT 0,
+        `name` VARCHAR(255) NOT NULL,
+        `path` VARCHAR(255) NOT NULL,
+        `size` INT UNSIGNED NOT NULL DEFAULT 0,
+        `created_at` INT UNSIGNED NOT NULL,
+        `updated_at` INT UNSIGNED NOT NULL,
+        PRIMARY KEY (`template_id`),
+        KEY `company_id` (`company_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8
         ]]></item>
 
         <!-- uninstall -->

--- a/app/addons/mwl_xlsx/controllers/backend/mwl_xlsx_templates.php
+++ b/app/addons/mwl_xlsx/controllers/backend/mwl_xlsx_templates.php
@@ -1,0 +1,93 @@
+<?php
+
+use Tygh\Registry;
+use Tygh\Storage;
+use Tygh\Tools\SecurityHelper;
+
+if (!defined('BOOTSTRAP')) { die('Access denied'); }
+
+$storage = Storage::instance('custom_files'); // хранение в var/files/ (S3 и др. тоже ок)
+$company_id = fn_get_runtime_company_id();
+
+//
+// POST
+//
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+
+    if ($mode === 'upload') {
+        // ожидаем input name = xlsx_template
+        $uploaded = fn_filter_uploaded_data('xlsx_template'); // массив файлов от fileuploader
+
+        if (!empty($uploaded)) {
+            $file = reset($uploaded);
+            if (!empty($file['path']) && empty($file['error'])) {
+                // защита: только .xlsx
+                $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+                if ($ext !== 'xlsx') {
+                    fn_set_notification('E', __('error'), __('text_invalid_file_type'));
+                } else {
+                    // нормализуем имя и избегаем коллизий
+                    $basename = SecurityHelper::sanitizeFileName(pathinfo($file['name'], PATHINFO_FILENAME));
+                    $fname = $basename . '-' . substr(sha1(uniqid('', true)), 0, 8) . '.xlsx';
+
+                    $dst = 'mwl_xlsx/templates/' . (int)$company_id . '/' . $fname;
+                    $put = $storage->put($dst, ['file' => $file['path']]);
+
+                    if ($put) {
+                        $now = TIME;
+                        db_query(
+                            "INSERT INTO ?:mwl_xlsx_templates ?e",
+                            [
+                                'company_id' => (int)$company_id,
+                                'name'       => $file['name'], // оригинальное имя
+                                'path'       => $dst,           // относительный путь в сторадже
+                                'size'       => (int)$file['size'],
+                                'created_at' => $now,
+                                'updated_at' => $now,
+                            ]
+                        );
+                        fn_set_notification('N', __('notice'), __('file_uploaded'));
+                    } else {
+                        fn_set_notification('E', __('error'), __('cant_upload_file'));
+                    }
+                }
+            } else {
+                fn_set_notification('E', __('error'), __('cant_upload_file'));
+            }
+        }
+
+        return [CONTROLLER_STATUS_OK, 'mwl_xlsx_templates.manage'];
+    }
+
+    if ($mode === 'delete' && !empty($_REQUEST['template_id'])) {
+        $tpl = db_get_row(
+            "SELECT * FROM ?:mwl_xlsx_templates WHERE template_id = ?i AND company_id IN (?n)",
+            (int) $_REQUEST['template_id'],
+            $company_id ? [$company_id] : [0, $company_id] // админ может видеть 0/все
+        );
+        if ($tpl) {
+            $storage->delete($tpl['path']);
+            db_query("DELETE FROM ?:mwl_xlsx_templates WHERE template_id = ?i", (int)$tpl['template_id']);
+            fn_set_notification('N', __('notice'), __('deleted'));
+        }
+        return [CONTROLLER_STATUS_OK, 'mwl_xlsx_templates.manage'];
+    }
+
+    return [CONTROLLER_STATUS_OK];
+}
+
+//
+// GET
+//
+if ($mode === 'manage') {
+    $condition = $company_id
+        ? db_quote(" WHERE company_id = ?i", $company_id)
+        : '';
+    $templates = db_get_array("SELECT * FROM ?:mwl_xlsx_templates ?p ORDER BY template_id DESC", $condition);
+
+    Tygh::$app['view']->assign([
+        'mwl_xlsx_templates' => $templates,
+        'company_id'         => $company_id,
+    ]);
+}
+

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -1,5 +1,6 @@
 <?php
 use Tygh\Registry;
+use Tygh\Storage;
 
 if (!defined('BOOTSTRAP')) { die('Access denied'); }
 
@@ -161,3 +162,10 @@ function fn_mwl_xlsx_delete_list($list_id, $user_id = null, $session_id = null)
     }
     return false;
 }
+
+function fn_mwl_xlsx_uninstall()
+{
+    db_query("DROP TABLE IF EXISTS ?:mwl_xlsx_templates");
+    Storage::instance('custom_files')->deleteDir('mwl_xlsx/templates');
+}
+

--- a/app/addons/mwl_xlsx/schemas/menu/menu.post.php
+++ b/app/addons/mwl_xlsx/schemas/menu/menu.post.php
@@ -1,0 +1,13 @@
+<?php
+$schema['central']['mwl_xlsx'] = [
+    'position' => 500,
+    'items' => [
+        'xlsx_templates' => [
+            'href'        => 'mwl_xlsx_templates.manage',
+            'position'    => 100,
+            'permissions' => 'view_catalog',
+        ],
+    ],
+];
+return $schema;
+

--- a/app/addons/mwl_xlsx/schemas/permissions/admin.post.php
+++ b/app/addons/mwl_xlsx/schemas/permissions/admin.post.php
@@ -1,0 +1,6 @@
+<?php
+$schema['mwl_xlsx_templates'] = [
+    'permissions' => ['GET' => 'view_catalog', 'POST' => 'manage_catalog'],
+];
+return $schema;
+

--- a/design/backend/templates/addons/mwl_xlsx/views/mwl_xlsx_templates/manage.tpl
+++ b/design/backend/templates/addons/mwl_xlsx/views/mwl_xlsx_templates/manage.tpl
@@ -1,0 +1,68 @@
+{capture name="mainbox"}
+
+<form action="{""|fn_url}" method="post" class="form-horizontal form-edit" enctype="multipart/form-data" name="mwl_xlsx_upload_form">
+    <input type="hidden" name="result_ids" value="content_templates_list"/>
+
+    <div class="control-group">
+        <label class="control-label">{__("upload")}</label>
+        <div class="controls">
+            {include file="common/fileuploader.tpl"
+                var_name="xlsx_template"
+                allowed_ext="xlsx"
+                upload_an_image=false
+                label=__("mwl_xlsx.upload_xlsx_template")
+            }
+            {include file="buttons/button.tpl"
+                but_role="submit"
+                but_text=__("upload")
+                but_name="dispatch[mwl_xlsx_templates.upload]"
+                but_meta="btn-primary"
+            }
+        </div>
+    </div>
+</form>
+
+<div id="content_templates_list">
+    {if $mwl_xlsx_templates}
+        <table class="table table-middle">
+            <thead>
+                <tr>
+                    <th width="40">#</th>
+                    <th>{__("name")}</th>
+                    <th class="center">{__("size")}</th>
+                    <th class="right">{__("date")}</th>
+                    <th class="right">{__("tools")}</th>
+                </tr>
+            </thead>
+            <tbody>
+            {foreach from=$mwl_xlsx_templates item=t}
+                <tr>
+                    <td>{$t.template_id}</td>
+                    <td>{$t.name}</td>
+                    <td class="center">{($t.size/1024)|ceil} KB</td>
+                    <td class="right">{($t.created_at)|date_format:"%d.%m.%Y %H:%M"}</td>
+                    <td class="right">
+                        {include file="buttons/button.tpl"
+                            but_role="text"
+                            but_meta="cm-confirm"
+                            but_text=__("delete")
+                            but_name="dispatch[mwl_xlsx_templates.delete]"
+                            but_href="mwl_xlsx_templates.delete?template_id=`$t.template_id`"
+                        }
+                    </td>
+                </tr>
+            {/foreach}
+            </tbody>
+        </table>
+    {else}
+        {include file="common/no_items.tpl"}
+    {/if}
+<!--content_templates_list--></div>
+
+{/capture}
+
+{include file="common/mainbox.tpl"
+    title=__("mwl_xlsx.xlsx_templates")
+    content=$smarty.capture.mainbox
+}
+

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -64,3 +64,11 @@ msgctxt "Languages::mwl_xlsx.add_all_to_wishlist"
 msgid "Add all to wishlist"
 msgstr "Add all to wishlist"
 
+msgctxt "Languages::mwl_xlsx.xlsx_templates"
+msgid "XLSX templates"
+msgstr "XLSX templates"
+
+msgctxt "Languages::mwl_xlsx.upload_xlsx_template"
+msgid "Upload XLSX template"
+msgstr "Upload XLSX template"
+

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -66,3 +66,11 @@ msgctxt "Languages::mwl_xlsx.add_all_to_wishlist"
 msgid "Add all to wishlist"
 msgstr "Добавить все в список желаний"
 
+msgctxt "Languages::mwl_xlsx.xlsx_templates"
+msgid "XLSX templates"
+msgstr "XLSX-шаблоны"
+
+msgctxt "Languages::mwl_xlsx.upload_xlsx_template"
+msgid "Upload XLSX template"
+msgstr "Загрузить XLSX-шаблон"
+


### PR DESCRIPTION
## Summary
- allow admins to upload and delete XLSX templates stored via `Tygh\Storage`
- add permissions and menu entry for managing templates
- document feature and language strings

## Testing
- `php -l app/addons/mwl_xlsx/func.php`
- `php -l app/addons/mwl_xlsx/controllers/backend/mwl_xlsx_templates.php`
- `php -l app/addons/mwl_xlsx/schemas/permissions/admin.post.php`
- `php -l app/addons/mwl_xlsx/schemas/menu/menu.post.php`
- `xmllint --noout app/addons/mwl_xlsx/addon.xml`


------
https://chatgpt.com/codex/tasks/task_e_689cb4a7aa30832ca8b5a16fc46ebae1