### PR TITLE
feat: add export on wishlist view

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - View existing wishlists on the **My wishlists** page.
 - Each wishlist shows the number of products and links to its own page.
 - View products of a wishlist on a dedicated page.
-- Export wishlists to XLSX files from the wishlist list page, placing each product feature in its own column and translating product and feature data into the site's current language.
+- Export wishlists to XLSX files from the wishlist list page or an individual wishlist page, placing each product feature in its own column and translating product and feature data into the site's current language.
 - Manage a single XLSX template from the admin panel for custom export layouts; uploading a new file replaces the previous template and exports use it when available.
 - Navigate wishlists with breadcrumbs and page titles.
 - Rename or remove wishlists from the manage page.
@@ -25,9 +25,6 @@
 - `index.php?dispatch=mwl_xlsx.add` – add a product to a wishlist (POST).
 - `index.php?dispatch=mwl_xlsx.rename_list` – rename a wishlist (POST).
 - `index.php?dispatch=mwl_xlsx.delete_list` – remove a wishlist (POST).
-
-### TODO
-- [ ] Export wishlist to XLSX on a single wishlist page.
 
 ### Dev install
 

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
@@ -1,4 +1,5 @@
 {capture name="mainbox"}
+    <a class="mwl_xlsx-export" href="{fn_url("mwl_xlsx.export?list_id=`$list.list_id`")}" title="{__("mwl_xlsx.export")}"><img src="{$images_dir}/addons/mwl_xlsx/xlsx.svg" alt="{__("mwl_xlsx.export")}" width="20" height="20" /></a>
     {if $products}
         {include file="blocks/list_templates/products_list.tpl"
             products=$products


### PR DESCRIPTION
## Summary
- add export button to wishlist view page before product list
- document exporting wishlist from its page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d0d599d5c832c9d1d437b858fd95a