### PR TITLE
Add removal from media lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - View existing media lists on the **My media lists** page.
 - Each media list shows the number of products and links to its own page.
 - View products of a media list on a dedicated page.
+- Remove products from a media list directly from its page.
 - Export media lists to XLSX files from the media lists page, placing each product feature in its own column and translating product and feature data into the site's current language.
 - Manage a single XLSX template from the admin panel for custom export layouts; uploading a new file replaces the previous template and exports use it when available.
 - Navigate media lists with breadcrumbs and page titles.
@@ -23,6 +24,7 @@
 - `index.php?dispatch=mwl_xlsx.view&list_id={list_id}` – view a media list.
 - `index.php?dispatch=mwl_xlsx.create_list` – create a media list (POST).
 - `index.php?dispatch=mwl_xlsx.add` – add a product to a media list (POST).
+- `index.php?dispatch=mwl_xlsx.remove` – remove a product from a media list (POST).
 - `index.php?dispatch=mwl_xlsx.rename_list` – rename a media list (POST).
 - `index.php?dispatch=mwl_xlsx.delete_list` – remove a media list (POST).
 

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -82,6 +82,8 @@
                 <value id="mwl_xlsx.confirm_remove">Remove this list?</value>
                 <value id="mwl_xlsx.add_all_to_wishlist">Add all to media list</value>
                 <value id="mwl_xlsx.add_to_wishlist">Add to media list</value>
+                <value id="mwl_xlsx.remove_from_list">Remove from list</value>
+                <value id="mwl_xlsx.removed">Removed</value>
             </values>
         </item>
         <item>
@@ -100,6 +102,8 @@
                 <value id="mwl_xlsx.confirm_remove">Удалить эту подборку?</value>
                 <value id="mwl_xlsx.add_all_to_wishlist">Добавить все в подборку</value>
                 <value id="mwl_xlsx.add_to_wishlist">Добавить в подборку</value>
+                <value id="mwl_xlsx.remove_from_list">Удалить из подборки</value>
+                <value id="mwl_xlsx.removed">Удалено</value>
             </values>
         </item>
     </languages>

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -28,6 +28,7 @@ if ($mode === 'list' || $mode === 'view') {
     }
     if ($list) {
         $products = fn_mwl_xlsx_get_list_products($list_id, CART_LANGUAGE);
+        Tygh::$app['view']->assign('is_mwl_xlsx_view', true);
         Tygh::$app['view']->assign('list', $list);
         Tygh::$app['view']->assign('products', $products);
         Tygh::$app['view']->assign('search', [

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -148,6 +148,12 @@ if ($mode === 'add' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     exit(json_encode(['success' => true, 'message' => $message]));
 }
 
+if ($mode === 'remove' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $list_id = (int) $_REQUEST['list_id'];
+    $removed = fn_mwl_xlsx_remove($list_id, $_REQUEST['product_id']);
+    exit(json_encode(['success' => $removed]));
+}
+
 if ($mode === 'add_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     $list_id = (int) $_REQUEST['list_id'];
     $product_ids = array_slice(array_unique(array_map('intval', (array) ($_REQUEST['product_ids'] ?? []))), 0, 20);

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -52,6 +52,7 @@ function fn_mwl_xlsx_get_list_products($list_id, $lang_code = CART_LANGUAGE)
             $product['product_features'] = $features;
             $product['selected_options'] = empty($item['product_options']) ? [] : @unserialize($item['product_options']);
             $product['amount'] = $item['amount'];
+            $product['mwl_list_id'] = $list_id;
             $products[] = $product;
         }
     }
@@ -132,6 +133,17 @@ function fn_mwl_xlsx_add($list_id, $product_id, $options = [], $amount = 1)
     ]);
 
     return true;
+}
+
+function fn_mwl_xlsx_remove($list_id, $product_id)
+{
+    $deleted = db_query(
+        "DELETE FROM ?:mwl_xlsx_list_products WHERE list_id = ?i AND product_id = ?i",
+        $list_id,
+        $product_id
+    );
+
+    return (bool) $deleted;
 }
 
 function fn_mwl_xlsx_update_list_name($list_id, $name, $user_id = null, $session_id = null)

--- a/js/addons/mwl_xlsx/mwl_xlsx.js
+++ b/js/addons/mwl_xlsx/mwl_xlsx.js
@@ -39,6 +39,23 @@
     return false;
   });
 
+  $(_.doc).on('click', '[data-ca-remove-from-mwl_xlsx]', function() {
+    var $btn = $(this);
+    var list_id = $btn.data('caListId');
+    var product_id = $btn.data('caProductId');
+    $.ceAjax('request', fn_url('mwl_xlsx.remove'), {
+      method: 'post',
+      data: { list_id: list_id, product_id: product_id },
+      callback: function(data) {
+        data = parseResponse(data);
+        if (data && data.success) {
+          $btn.text(_.tr('mwl_xlsx.removed') || 'Removed').prop('disabled', true);
+        }
+      }
+    });
+    return false;
+  });
+
   var $renameDialog = $('#mwl_xlsx_rename_dialog');
   var $deleteDialog = $('#mwl_xlsx_delete_dialog');
   var $newListDialog = $('#mwl_xlsx_new_list_dialog');

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -76,3 +76,11 @@ msgctxt "Languages::mwl_xlsx.add_to_wishlist"
 msgid "Add to media list"
 msgstr "Add to media list"
 
+msgctxt "Languages::mwl_xlsx.remove_from_list"
+msgid "Remove from list"
+msgstr "Remove from list"
+
+msgctxt "Languages::mwl_xlsx.removed"
+msgid "Removed"
+msgstr "Removed"
+

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -78,3 +78,11 @@ msgctxt "Languages::mwl_xlsx.add_to_wishlist"
 msgid "Add to media list"
 msgstr "Добавить в подборку"
 
+msgctxt "Languages::mwl_xlsx.remove_from_list"
+msgid "Remove from list"
+msgstr "Удалить из подборки"
+
+msgctxt "Languages::mwl_xlsx.removed"
+msgid "Removed"
+msgstr "Удалено"
+

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
@@ -16,8 +16,9 @@
             {__("mwl_xlsx.add_to_wishlist")}
         </button>
     </div>
-{elseif $runtime.controller == 'mwl_xlsx' && ($runtime.mode == 'list' || $runtime.mode == 'view')}
+{elseif !empty($is_mwl_xlsx_view)}
     <div class="mwl_xlsx-control">
+        <br>
         <button class="ty-btn" data-ca-remove-from-mwl_xlsx data-ca-product-id="{$product.product_id}" data-ca-list-id="{$product.mwl_list_id}">
             {__("mwl_xlsx.remove_from_list")}
         </button>

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
@@ -16,4 +16,10 @@
             {__("mwl_xlsx.add_to_wishlist")}
         </button>
     </div>
+{elseif $runtime.controller == 'mwl_xlsx' && ($runtime.mode == 'list' || $runtime.mode == 'view')}
+    <div class="mwl_xlsx-control">
+        <button class="ty-btn" data-ca-remove-from-mwl_xlsx data-ca-product-id="{$product.product_id}" data-ca-list-id="{$product.mwl_list_id}">
+            {__("mwl_xlsx.remove_from_list")}
+        </button>
+    </div>
 {/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
@@ -2,6 +2,7 @@
     <a class="mwl_xlsx-export" href="{fn_url("mwl_xlsx.export?list_id=`$list.list_id`")}" title="{__("mwl_xlsx.export")}"><img src="{$images_dir}/addons/mwl_xlsx/xlsx.svg" alt="{__("mwl_xlsx.export")}" width="20" height="20" /></a>
     {if $products}
         {include file="blocks/list_templates/products_list.tpl"
+            is_mwl_xlsx_view=true
             products=$products
             layout="products_without_options"
 
@@ -14,7 +15,7 @@
             show_rating=true
             show_product_amount=true
             show_discount_label=true
-            show_add_to_cart=false
+            show_add_to_cart=true
             but_role="action"
 
             no_pagination=true


### PR DESCRIPTION
## Summary
- add 'Remove from list' button on media list pages
- support removing products via new endpoint and JS
- document removal feature and translations

## Testing
- `php -l app/addons/mwl_xlsx/func.php`
- `php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`
- `node --check js/addons/mwl_xlsx/mwl_xlsx.js`


------
https://chatgpt.com/codex/tasks/task_e_689d9c5a7474832c81eb5b5d67d63ed7