### PR TITLE
Add updated timestamp to media lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - Manage a single XLSX template from the admin panel for custom export layouts; uploading a new file replaces the previous template and exports use it when available.
 - Navigate media lists with breadcrumbs and page titles.
 - Rename or remove media lists from the manage page.
+- Track when each media list was last updated.
 - SEO-friendly URLs for media list pages (`/media-lists` and `/media-lists/{list_id}`).
 
 ### Add-on URLs

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -24,7 +24,8 @@
         `session_id` VARCHAR(64) NOT NULL DEFAULT '',
         `name` VARCHAR(255) NOT NULL,
         `is_private` TINYINT(1) NOT NULL DEFAULT 0,
-        `created_at` DATETIME NOT NULL
+        `created_at` DATETIME NOT NULL,
+        `updated_at` DATETIME NOT NULL
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
         ]]></item>
 

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -107,11 +107,13 @@ if ($mode === 'export') {
 }
 
 if ($mode === 'create_list' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $now  = date('Y-m-d H:i:s');
     $data = [
         'user_id'    => $auth['user_id'] ?? 0,
         'session_id' => $auth['user_id'] ? '' : Tygh::$app['session']->getID(),
         'name'       => $_REQUEST['name'],
-        'created_at' => date('Y-m-d H:i:s')
+        'created_at' => $now,
+        'updated_at' => $now,
     ];
     $list_id = db_query("INSERT INTO ?:mwl_xlsx_lists ?e", $data);
     exit(json_encode(['list_id' => $list_id, 'name' => $data['name']]));

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -132,6 +132,8 @@ function fn_mwl_xlsx_add($list_id, $product_id, $options = [], $amount = 1)
         'timestamp'      => TIME
     ]);
 
+    db_query('UPDATE ?:mwl_xlsx_lists SET updated_at = ?s WHERE list_id = ?i', date('Y-m-d H:i:s'), $list_id);
+
     return true;
 }
 
@@ -142,6 +144,10 @@ function fn_mwl_xlsx_remove($list_id, $product_id)
         $list_id,
         $product_id
     );
+
+    if ($deleted) {
+        db_query('UPDATE ?:mwl_xlsx_lists SET updated_at = ?s WHERE list_id = ?i', date('Y-m-d H:i:s'), $list_id);
+    }
 
     return (bool) $deleted;
 }
@@ -154,7 +160,7 @@ function fn_mwl_xlsx_update_list_name($list_id, $name, $user_id = null, $session
     $condition = $user_id ? ['list_id' => $list_id, 'user_id' => $user_id] : ['list_id' => $list_id, 'session_id' => $session_id];
     $exists = db_get_field('SELECT list_id FROM ?:mwl_xlsx_lists WHERE ?w', $condition);
     if ($exists) {
-        db_query('UPDATE ?:mwl_xlsx_lists SET name = ?s WHERE list_id = ?i', $name, $list_id);
+        db_query('UPDATE ?:mwl_xlsx_lists SET name = ?s, updated_at = ?s WHERE list_id = ?i', $name, date('Y-m-d H:i:s'), $list_id);
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- track media list modification time via new `updated_at` column
- keep `updated_at` in sync when lists are created, renamed, or modified
- document update timestamp feature in README

## Testing
- `php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php`
- `php -l app/addons/mwl_xlsx/func.php`


------
https://chatgpt.com/codex/tasks/task_e_689df4cb3554832cb70d9ffdb3636987