### PR TITLE
Add media lists counter block

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - Rename or remove media lists from the manage page.
 - Track when each media list was last updated.
 - SEO-friendly URLs for media list pages (`/media-lists` and `/media-lists/{list_id}`).
+- UT2 top panel block displaying the total number of products across all media lists.
 
 ### Add-on URLs
 - `/media-lists` – list user media lists.

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -28,6 +28,32 @@ function fn_mwl_xlsx_get_lists($user_id = null, $session_id = null)
     );
 }
 
+/**
+ * Returns the total number of products in all media lists of the current user or session.
+ *
+ * @param array $auth Authentication data
+ *
+ * @return int
+ */
+function fn_mwl_xlsx_get_media_lists_count(array $auth)
+{
+    if (!empty($auth['user_id'])) {
+        $condition = db_quote('l.user_id = ?i', $auth['user_id']);
+    } else {
+        $session_id = Tygh::$app['session']->getID();
+        $condition = db_quote('l.session_id = ?s', $session_id);
+    }
+
+    $count = (int) db_get_field(
+        'SELECT SUM(lp.amount) FROM ?:mwl_xlsx_lists AS l '
+        . 'LEFT JOIN ?:mwl_xlsx_list_products AS lp ON lp.list_id = l.list_id '
+        . 'WHERE ?p',
+        $condition
+    );
+
+    return $count;
+}
+
 function fn_mwl_xlsx_get_list_products($list_id, $lang_code = CART_LANGUAGE)
 {
     $items = db_get_hash_array(

--- a/app/addons/mwl_xlsx/schemas/block_manager/templates.post.php
+++ b/app/addons/mwl_xlsx/schemas/block_manager/templates.post.php
@@ -1,0 +1,20 @@
+<?php
+if (!defined('BOOTSTRAP')) { die('Access denied'); }
+
+// Добавляем наш шаблон в список шаблонов для блока "HTML с поддержкой Smarty" (smarty_block)
+$schema['smarty_block']['addons/mwl_xlsx/blocks/media_lists_counter.tpl'] = [
+    'name' => 'mwl_xlsx.block_media_lists_counter', // языковая переменная
+    'settings' => [
+        'link_url' => [
+            'type' => 'input',
+            'default_value' => 'media-lists', // можно указать dispatch или ЧПУ
+        ],
+        'show_zero' => [
+            'type' => 'checkbox',
+            'default_value' => 'N',
+        ],
+    ],
+    'wrappers' => 'blocks/wrappers', // пусть будут стандартные обёртки
+];
+
+return $schema;

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -99,3 +99,11 @@ msgstr "Items"
 msgctxt "Languages::mwl_xlsx.actions"
 msgid "Actions"
 msgstr "Actions"
+
+msgctxt "Languages::mwl_xlsx.block_media_lists_counter"
+msgid "Media lists counter"
+msgstr "Media lists counter"
+
+msgctxt "Languages::mwl_xlsx.media_lists"
+msgid "Media lists"
+msgstr "Media lists"

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -101,3 +101,11 @@ msgstr "Позиции"
 msgctxt "Languages::mwl_xlsx.actions"
 msgid "Actions"
 msgstr "Действия"
+
+msgctxt "Languages::mwl_xlsx.block_media_lists_counter"
+msgid "Media lists counter"
+msgstr "Счётчик подборок"
+
+msgctxt "Languages::mwl_xlsx.media_lists"
+msgid "Media lists"
+msgstr "Подборки"

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/blocks/media_lists_counter.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/blocks/media_lists_counter.tpl
@@ -1,0 +1,22 @@
+{* Шаблон счётчика media-lists для верхней панели UT2 *}
+{assign var="count" value=fn_mwl_xlsx_get_media_lists_count($auth)}
+{assign var="show_zero" value=$block.settings.show_zero|default:"N"}
+{assign var="link_url" value=$block.settings.link_url|default:"media-lists"}
+
+{* Поддержка как ЧПУ (/media-lists), так и dispatch (mwl_xlsx.manage / mwl_xlsx.view) *}
+{if $link_url|substr:0:1 == '/'}
+    {assign var="href" value=$link_url}
+{else}
+    {assign var="href" value=$link_url|fn_url}
+{/if}
+
+{if $count || $show_zero == "Y"}
+<div class="ut2-top-wishlist-count" id="mwl_media_lists_count">
+    <a class="cm-tooltip ty-wishlist__a {if $count}active{/if}" href="{$href}" rel="nofollow" title="{__("mwl_xlsx.media_lists")}">
+        <span>
+            <i class="ut2-icon-article"></i>
+            <span class="count">{$count}</span>
+        </span>
+    </a>
+</div>
+{/if}


### PR DESCRIPTION
## Summary
- add block manager schema and Smarty template for media lists counter
- compute total media list items for current user or session
- document feature and add translations

## Testing
- `php -l app/addons/mwl_xlsx/func.php`
- `php -l app/addons/mwl_xlsx/schemas/block_manager/templates.post.php`


------
https://chatgpt.com/codex/tasks/task_e_689df8ce4864832ca309551d9232beba