### PR TITLE
Add access control and price visibility settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - Hide prices for guests or unauthorized user groups.
 - Optional extra button in product lists for adding items to a media list.
 - Limit media list features to specific user groups.
+- Configure price visibility, extra list button, and access groups via the add-on's **Settings** page in the admin panel.
 
 ### Add-on URLs
 - `/media-lists` – list user media lists.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 - Track when each media list was last updated.
 - SEO-friendly URLs for media list pages (`/media-lists` and `/media-lists/{list_id}`).
 - UT2 top panel block displaying the number of media lists for the current user or session.
+- Hide prices for guests or unauthorized user groups.
+- Optional extra button in product lists for adding items to a media list.
+- Limit media list features to specific user groups.
 
 ### Add-on URLs
 - `/media-lists` – list user media lists.

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -85,6 +85,11 @@
                 <value id="mwl_xlsx.add_to_wishlist">Add to media list</value>
                 <value id="mwl_xlsx.remove_from_list">Remove from list</value>
                 <value id="mwl_xlsx.removed">Removed</value>
+                <value id="mwl_xlsx.hide_price_for_guests">Hide price for unauthorized</value>
+                <value id="mwl_xlsx.authorized_usergroups">Authorized user groups</value>
+                <value id="mwl_xlsx.show_extra_button">Show extra button in list</value>
+                <value id="mwl_xlsx.allowed_usergroups">User groups allowed for media lists</value>
+                <value id="mwl_xlsx.login_to_view_price">Log in to view price</value>
             </values>
         </item>
         <item>
@@ -105,20 +110,37 @@
                 <value id="mwl_xlsx.add_to_wishlist">Добавить в подборку</value>
                 <value id="mwl_xlsx.remove_from_list">Удалить из подборки</value>
                 <value id="mwl_xlsx.removed">Удалено</value>
+                <value id="mwl_xlsx.hide_price_for_guests">Скрывать цену для неавторизованных</value>
+                <value id="mwl_xlsx.authorized_usergroups">Группы пользователей авторизованных</value>
+                <value id="mwl_xlsx.show_extra_button">Выводить кнопку extra в списке</value>
+                <value id="mwl_xlsx.allowed_usergroups">Группы пользователей, которым разрешён доступ к mwl lists</value>
+                <value id="mwl_xlsx.login_to_view_price">Войдите, чтобы увидеть цену</value>
             </values>
         </item>
     </languages>
 
-    <!-- Настройки можно добавить позже
     <settings>
         <sections>
             <section id="general" name="General">
                 <items>
-                    <item id="allow_sharing" type="checkbox" name="Allow sharing by link" value="Y"/>
-                    <item id="default_list_name" type="input" name="Default list name" value="Favorites"/>
+                    <item id="hide_price_for_guests" type="checkbox">
+                        <name>mwl_xlsx.hide_price_for_guests</name>
+                        <value>N</value>
+                    </item>
+                    <item id="authorized_usergroups" type="selectbox" multiple="true">
+                        <name>mwl_xlsx.authorized_usergroups</name>
+                        <variants_function>fn_get_usergroups</variants_function>
+                    </item>
+                    <item id="show_extra_button" type="checkbox">
+                        <name>mwl_xlsx.show_extra_button</name>
+                        <value>Y</value>
+                    </item>
+                    <item id="allowed_usergroups" type="selectbox" multiple="true">
+                        <name>mwl_xlsx.allowed_usergroups</name>
+                        <variants_function>fn_get_usergroups</variants_function>
+                    </item>
                 </items>
             </section>
         </sections>
     </settings>
-    -->
 </addon>

--- a/app/addons/mwl_xlsx/controllers/backend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/backend/mwl_xlsx.php
@@ -9,3 +9,27 @@ if ($mode === 'dev_reload_langs') {
     fn_clear_cache(); // чтобы сразу увидеть обновления
     return [CONTROLLER_STATUS_OK, 'addons.update?addon=mwl_xlsx'];
 }
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $mode === 'settings') {
+    $settings = $_REQUEST['mwl_xlsx'] ?? [];
+
+    foreach ($settings as $name => $value) {
+        if (is_array($value)) {
+            $value = implode(',', $value);
+        }
+        \Tygh\Settings::instance()->updateValue($name, $value, 'mwl_xlsx');
+    }
+
+    fn_set_notification('N', __('notice'), __('mwl_xlsx.settings_saved'));
+    return [CONTROLLER_STATUS_OK, 'mwl_xlsx.settings'];
+}
+
+if ($mode === 'settings') {
+    $settings = Registry::get('addons.mwl_xlsx');
+    foreach (['authorized_usergroups', 'allowed_usergroups'] as $field) {
+        $settings[$field] = $settings[$field] ? explode(',', $settings[$field]) : [];
+    }
+
+    \Tygh::$app['view']->assign('mwl_xlsx', $settings);
+    \Tygh::$app['view']->assign('usergroups', fn_get_usergroups(['type' => 'C'], CART_LANGUAGE));
+}

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -5,6 +5,10 @@ use Tygh\Languages\Helper;
 use Tygh\Registry;
 use Tygh\Storage;
 
+if (!fn_mwl_xlsx_user_can_access_lists($auth)) {
+    return [CONTROLLER_STATUS_DENIED];
+}
+
 if ($mode === 'manage') {
     if (!empty($auth['user_id'])) {
         $lists = fn_mwl_xlsx_get_lists($auth['user_id']);

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -5,6 +5,46 @@ use Tygh\Storage;
 if (!defined('BOOTSTRAP')) { die('Access denied'); }
 
 /**
+ * Check whether the current customer may work with media lists.
+ *
+ * @param array $auth Current authentication data
+ *
+ * @return bool
+ */
+function fn_mwl_xlsx_user_can_access_lists(array $auth)
+{
+    $allowed = (array) Registry::get('addons.mwl_xlsx.allowed_usergroups');
+    if (!$allowed) {
+        return true;
+    }
+
+    $usergroups = array_keys($auth['usergroup_ids'] ?? []);
+    return (bool) array_intersect($allowed, $usergroups);
+}
+
+/**
+ * Determine if price should be shown to the current customer.
+ *
+ * @param array $auth Current authentication data
+ *
+ * @return bool
+ */
+function fn_mwl_xlsx_can_view_price(array $auth)
+{
+    if (Registry::get('addons.mwl_xlsx.hide_price_for_guests') === 'Y' && empty($auth['user_id'])) {
+        return false;
+    }
+
+    $allowed = (array) Registry::get('addons.mwl_xlsx.authorized_usergroups');
+    if (!$allowed) {
+        return true;
+    }
+
+    $usergroups = array_keys($auth['usergroup_ids'] ?? []);
+    return (bool) array_intersect($allowed, $usergroups);
+}
+
+/**
  * Ensures settings table exists.
  */
 function fn_mwl_xlsx_ensure_settings_table()

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -13,12 +13,13 @@ if (!defined('BOOTSTRAP')) { die('Access denied'); }
  */
 function fn_mwl_xlsx_user_can_access_lists(array $auth)
 {
-    $allowed = (array) Registry::get('addons.mwl_xlsx.allowed_usergroups');
+    $allowed = Registry::get('addons.mwl_xlsx.allowed_usergroups');
+    $allowed = $allowed !== '' ? array_map('intval', explode(',', $allowed)) : [];
     if (!$allowed) {
         return true;
     }
 
-    $usergroups = array_keys($auth['usergroup_ids'] ?? []);
+    $usergroups = array_map('intval', array_keys($auth['usergroup_ids'] ?? []));
     return (bool) array_intersect($allowed, $usergroups);
 }
 
@@ -35,12 +36,13 @@ function fn_mwl_xlsx_can_view_price(array $auth)
         return false;
     }
 
-    $allowed = (array) Registry::get('addons.mwl_xlsx.authorized_usergroups');
+    $allowed = Registry::get('addons.mwl_xlsx.authorized_usergroups');
+    $allowed = $allowed !== '' ? array_map('intval', explode(',', $allowed)) : [];
     if (!$allowed) {
         return true;
     }
 
-    $usergroups = array_keys($auth['usergroup_ids'] ?? []);
+    $usergroups = array_map('intval', array_keys($auth['usergroup_ids'] ?? []));
     return (bool) array_intersect($allowed, $usergroups);
 }
 

--- a/app/addons/mwl_xlsx/schemas/menu/menu.post.php
+++ b/app/addons/mwl_xlsx/schemas/menu/menu.post.php
@@ -8,7 +8,7 @@ $schema['central']['mwl_xlsx'] = [
             'permissions' => 'view_catalog',
         ],
         'settings' => [
-            'href'        => 'mwl_xlsx_templates.settings',
+            'href'        => 'mwl_xlsx.settings',
             'position'    => 200,
             'permissions' => 'view_catalog',
         ],

--- a/app/addons/mwl_xlsx/schemas/menu/menu.post.php
+++ b/app/addons/mwl_xlsx/schemas/menu/menu.post.php
@@ -7,6 +7,11 @@ $schema['central']['mwl_xlsx'] = [
             'position'    => 100,
             'permissions' => 'view_catalog',
         ],
+        'settings' => [
+            'href'        => 'mwl_xlsx_templates.settings',
+            'position'    => 200,
+            'permissions' => 'view_catalog',
+        ],
     ],
 ];
 return $schema;

--- a/design/backend/templates/addons/mwl_xlsx/views/mwl_xlsx/settings.tpl
+++ b/design/backend/templates/addons/mwl_xlsx/views/mwl_xlsx/settings.tpl
@@ -1,0 +1,49 @@
+{capture name="mainbox"}
+    <form action="{fn_url('')}" method="post" class="form-horizontal form-edit" name="mwl_xlsx_settings_form">
+        <input type="hidden" name="dispatch" value="mwl_xlsx.settings" />
+
+        <div class="control-group">
+            <label class="control-label" for="elm_hide_price_for_guests">{__("mwl_xlsx.hide_price_for_guests")}:</label>
+            <div class="controls">
+                <input type="hidden" name="mwl_xlsx[hide_price_for_guests]" value="N" />
+                <input type="checkbox" name="mwl_xlsx[hide_price_for_guests]" id="elm_hide_price_for_guests" value="Y" {if $mwl_xlsx.hide_price_for_guests == 'Y'}checked="checked"{/if} />
+            </div>
+        </div>
+
+        <div class="control-group">
+            <label class="control-label" for="elm_authorized_usergroups">{__("mwl_xlsx.authorized_usergroups")}:</label>
+            <div class="controls">
+                <select id="elm_authorized_usergroups" name="mwl_xlsx[authorized_usergroups][]" multiple="multiple" size="5">
+                    {foreach from=$usergroups item=ug}
+                        <option value="{$ug.usergroup_id}" {if $ug.usergroup_id|in_array:$mwl_xlsx.authorized_usergroups}selected="selected"{/if}>{$ug.usergroup}</option>
+                    {/foreach}
+                </select>
+            </div>
+        </div>
+
+        <div class="control-group">
+            <label class="control-label" for="elm_show_extra_button">{__("mwl_xlsx.show_extra_button")}:</label>
+            <div class="controls">
+                <input type="hidden" name="mwl_xlsx[show_extra_button]" value="N" />
+                <input type="checkbox" name="mwl_xlsx[show_extra_button]" id="elm_show_extra_button" value="Y" {if $mwl_xlsx.show_extra_button == 'Y'}checked="checked"{/if} />
+            </div>
+        </div>
+
+        <div class="control-group">
+            <label class="control-label" for="elm_allowed_usergroups">{__("mwl_xlsx.allowed_usergroups")}:</label>
+            <div class="controls">
+                <select id="elm_allowed_usergroups" name="mwl_xlsx[allowed_usergroups][]" multiple="multiple" size="5">
+                    {foreach from=$usergroups item=ug}
+                        <option value="{$ug.usergroup_id}" {if $ug.usergroup_id|in_array:$mwl_xlsx.allowed_usergroups}selected="selected"{/if}>{$ug.usergroup}</option>
+                    {/foreach}
+                </select>
+            </div>
+        </div>
+
+        <div class="buttons-container">
+            {include file="buttons/save_changes.tpl" but_name="dispatch[mwl_xlsx.settings]"}
+        </div>
+    </form>
+{/capture}
+
+{include file="common/mainbox.tpl" title=__('settings') content=$smarty.capture.mainbox}

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -139,3 +139,23 @@ msgstr "Media lists"
 msgctxt "Languages::mwl_xlsx.tooltip"
 msgid "You can add products to a media list and save it as an XLSX file."
 msgstr "You can add products to a media list and save it as an XLSX file."
+
+msgctxt "Languages::mwl_xlsx.hide_price_for_guests"
+msgid "Hide price for unauthorized"
+msgstr "Hide price for unauthorized"
+
+msgctxt "Languages::mwl_xlsx.authorized_usergroups"
+msgid "Authorized user groups"
+msgstr "Authorized user groups"
+
+msgctxt "Languages::mwl_xlsx.show_extra_button"
+msgid "Show extra button in list"
+msgstr "Show extra button in list"
+
+msgctxt "Languages::mwl_xlsx.allowed_usergroups"
+msgid "User groups allowed for media lists"
+msgstr "User groups allowed for media lists"
+
+msgctxt "Languages::mwl_xlsx.login_to_view_price"
+msgid "Log in to view price"
+msgstr "Log in to view price"

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -133,3 +133,23 @@ msgstr "Подборки"
 msgctxt "Languages::mwl_xlsx.tooltip"
 msgid "You can add products to a media list and save it as an XLSX file."
 msgstr "Вы можете добавить товары в подборку и сохранить как файл XLSX."
+
+msgctxt "Languages::mwl_xlsx.hide_price_for_guests"
+msgid "Hide price for unauthorized"
+msgstr "Скрывать цену для неавторизованных"
+
+msgctxt "Languages::mwl_xlsx.authorized_usergroups"
+msgid "Authorized user groups"
+msgstr "Группы пользователей авторизованных"
+
+msgctxt "Languages::mwl_xlsx.show_extra_button"
+msgid "Show extra button in list"
+msgstr "Выводить кнопку extra в списке"
+
+msgctxt "Languages::mwl_xlsx.allowed_usergroups"
+msgid "User groups allowed for media lists"
+msgstr "Группы пользователей, которым разрешён доступ к mwl lists"
+
+msgctxt "Languages::mwl_xlsx.login_to_view_price"
+msgid "Log in to view price"
+msgstr "Войдите, чтобы увидеть цену"

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -70,10 +70,6 @@ msgctxt "Languages::mwl_xlsx.add_all_to_wishlist"
 msgid "Add all to media list"
 msgstr "Добавить все в подборку"
 
-msgctxt "Languages::mwl_xlsx.xlsx_templates"
-msgid "XLSX templates"
-msgstr "XLSX-шаблоны"
-
 msgctxt "Languages::mwl_xlsx.upload_xlsx_template"
 msgid "Upload XLSX template"
 msgstr "Загрузить XLSX-шаблон"
@@ -101,10 +97,6 @@ msgstr "Всего изданий"
 msgctxt "Languages::mwl_xlsx.actions"
 msgid "Actions"
 msgstr "Скачать подборку"
-
-msgctxt "Languages::mwl_xlsx.settings"
-msgid "Settings"
-msgstr "Настройки"
 
 msgctxt "Languages::mwl_xlsx.price_multiplier"
 msgid "Price multiplier"

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/ab__s_pictograms_pos_2.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/ab__s_pictograms_pos_2.post.tpl
@@ -1,7 +1,7 @@
-{if fn_mwl_xlsx_user_can_access_lists($auth) && $addons.mwl_xlsx.show_extra_button == "Y"}
-    <div class="mwl_xlsx-control">
-        <button class="ty-btn" data-ca-add-to-mwl_xlsx data-ca-product-id="{$product.product_id}">
-            {__("mwl_xlsx.add_to_wishlist")}
-        </button>
-    </div>
+{if $addons.mwl_xlsx.show_extra_button == "Y" && !$quick_view && $product.product_id && !($runtime.controller == 'products' && $runtime.mode == 'view')}
+    {assign var=product_url value=fn_url("products.view?product_id=`$product.product_id`")}
+    <a href="{$product_url}"
+       class="mwl-more-btn">
+        {__("extra")}
+    </a>
 {/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/ab__s_pictograms_pos_2.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/ab__s_pictograms_pos_2.post.tpl
@@ -1,7 +1,7 @@
-{if !$quick_view && $product.product_id && !($runtime.controller == 'products' && $runtime.mode == 'view')}
-    {assign var=product_url value=fn_url("products.view?product_id=`$product.product_id`")}
-    <a href="{$product_url}"
-       class="mwl-more-btn">
-        {__("extra")}
-    </a>
+{if fn_mwl_xlsx_user_can_access_lists($auth) && $addons.mwl_xlsx.show_extra_button == "Y"}
+    <div class="mwl_xlsx-control">
+        <button class="ty-btn" data-ca-add-to-mwl_xlsx data-ca-product-id="{$product.product_id}">
+            {__("mwl_xlsx.add_to_wishlist")}
+        </button>
+    </div>
 {/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
@@ -1,33 +1,37 @@
-{if ($runtime.controller == 'products' && $runtime.mode == 'view')
-|| ($runtime.controller == 'categories' && $runtime.mode == 'view')
-|| ($runtime.controller == 'companies' && $runtime.mode == 'products')
-}
-    {if $auth}
-        {assign var=lists value=fn_mwl_xlsx_get_lists($auth.user_id)}
-    {else}
-        {assign var=lists value=fn_mwl_xlsx_get_lists(null)}
+{if fn_mwl_xlsx_user_can_access_lists($auth)}
+    {if ($runtime.controller == 'products' && $runtime.mode == 'view')
+    || ($runtime.controller == 'categories' && $runtime.mode == 'view')
+    || ($runtime.controller == 'companies' && $runtime.mode == 'products')
+    }
+        {if $addons.mwl_xlsx.show_extra_button == "Y"}
+            {if $auth}
+                {assign var=lists value=fn_mwl_xlsx_get_lists($auth.user_id)}
+            {else}
+                {assign var=lists value=fn_mwl_xlsx_get_lists(null)}
+            {/if}
+
+            <div class="mwl_xlsx-control">
+                <select class="mwl_xlsx-select" data-ca-list-select-xlsx>
+                    {foreach $lists as $l}
+                        <option value="{$l.list_id}">{$l.name}</option>
+                    {/foreach}
+                    <option value="_new">+ {__("mwl_xlsx.new_list")}</option>
+                </select>
+                <button class="ty-btn" data-ca-add-to-mwl_xlsx data-ca-product-id="{$product.product_id}">
+                    {__("mwl_xlsx.add_to_wishlist")}
+                </button>
+
+                <span class="ty-price-hint cm-tooltip ty-icon-help-circle" title="{__("mwl_xlsx.tooltip")}">
+                </span>
+            </div>
+        {/if}
+
+    {elseif !empty($is_mwl_xlsx_view)}
+        <div class="mwl_xlsx-control">
+            <br>
+            <button class="ty-btn" data-ca-remove-from-mwl_xlsx data-ca-product-id="{$product.product_id}" data-ca-list-id="{$product.mwl_list_id}">
+                {__("mwl_xlsx.remove_from_list")}
+            </button>
+        </div>
     {/if}
-
-    <div class="mwl_xlsx-control">
-        <select class="mwl_xlsx-select" data-ca-list-select-xlsx>
-            {foreach $lists as $l}
-                <option value="{$l.list_id}">{$l.name}</option>
-            {/foreach}
-            <option value="_new">+ {__("mwl_xlsx.new_list")}</option>
-        </select>
-        <button class="ty-btn" data-ca-add-to-mwl_xlsx data-ca-product-id="{$product.product_id}">
-            {__("mwl_xlsx.add_to_wishlist")}
-        </button>
-
-        <span class="ty-price-hint cm-tooltip ty-icon-help-circle" title="{__("mwl_xlsx.tooltip")}">
-        </span>
-    </div>
-
-{elseif !empty($is_mwl_xlsx_view)}
-    <div class="mwl_xlsx-control">
-        <br>
-        <button class="ty-btn" data-ca-remove-from-mwl_xlsx data-ca-product-id="{$product.product_id}" data-ca-list-id="{$product.mwl_list_id}">
-            {__("mwl_xlsx.remove_from_list")}
-        </button>
-    </div>
 {/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/price.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/price.tpl
@@ -1,0 +1,5 @@
+{if !fn_mwl_xlsx_can_view_price($auth)}
+    {capture name="price"}
+        <span class="mwl-xlsx-login-to-view">{__("mwl_xlsx.login_to_view_price")}</span>
+    {/capture}
+{/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/product_block.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/product_block.post.tpl
@@ -1,53 +1,55 @@
 {* design/themes/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/product_block.post.tpl *}
-{if ($runtime.controller == 'categories' && $runtime.mode == 'view')
-|| ($runtime.controller == 'companies' && $runtime.mode == 'products')
-}
+{if fn_mwl_xlsx_user_can_access_lists($auth) && $addons.mwl_xlsx.show_extra_button == "Y"}
+    {if ($runtime.controller == 'categories' && $runtime.mode == 'view')
+    || ($runtime.controller == 'companies' && $runtime.mode == 'products')
+    }
 
-    {if $smarty.foreach.products.first}
-        {assign var="mwl_xlsx_ids" value=[] scope="root"}
-    {/if}
-
-    {append var="mwl_xlsx_ids" value=$product.product_id scope="root"}
-
-    {if $smarty.foreach.products.last}
-        <span class="mwl-products-on-page"
-              data-block-id="{$block.block_id|default:0}"
-              data-product-ids-json='{$mwl_xlsx_ids|json_encode nofilter}'
-              hidden></span>
-
-        <script>
-        (function(_, $) {
-          _.mwl_products_on_page = _.mwl_products_on_page || {};
-          var bid = {$block.block_id|default:0};
-          var ids = {$mwl_xlsx_ids|json_encode nofilter} || [];
-          if (!Array.isArray(ids)) {
-            ids = String(ids || '').split(',').filter(Boolean).map(Number);
-          }
-          var prev = _.mwl_products_on_page[bid] || [];
-          var uniq = {};
-          prev.concat(ids).forEach(function(x){ if (x != null) uniq[x] = 1; });
-          _.mwl_products_on_page[bid] = Object.keys(uniq).map(Number);
-          $.ceEvent('trigger', 'mwl.products_on_page.updated', [bid, _.mwl_products_on_page[bid]]);
-        }(Tygh, Tygh.$));
-        </script>
-
-        {if $auth}
-            {assign var=lists value=fn_mwl_xlsx_get_lists($auth.user_id)}
-        {else}
-            {assign var=lists value=fn_mwl_xlsx_get_lists(null)}
+        {if $smarty.foreach.products.first}
+            {assign var="mwl_xlsx_ids" value=[] scope="root"}
         {/if}
-        <div class="mwl_xlsx-control mwl_xlsx-control--category">
-            <select class="mwl_xlsx-select" data-ca-list-select-xlsx>
-                {foreach $lists as $l}
-                    <option value="{$l.list_id}">{$l.name}</option>
-                {/foreach}
-                <option value="_new">+ {__("mwl_xlsx.new_list")}</option>
-            </select>
-            <input type="text" class="mwl_xlsx-new-name ty-input-text" data-ca-mwl-new-list-name style="display:none" placeholder="{__("mwl_xlsx.enter_list_name")}">
-            <button class="ty-btn" data-ca-add-all-to-mwl_xlsx data-ca-product-ids="{","|implode:$mwl_xlsx_ids}">
-                {__("mwl_xlsx.add_all_to_wishlist")}
-            </button>
-        </div>
-    {/if}
 
+        {append var="mwl_xlsx_ids" value=$product.product_id scope="root"}
+
+        {if $smarty.foreach.products.last}
+            <span class="mwl-products-on-page"
+                  data-block-id="{$block.block_id|default:0}"
+                  data-product-ids-json='{$mwl_xlsx_ids|json_encode nofilter}'
+                  hidden></span>
+
+            <script>
+            (function(_, $) {
+              _.mwl_products_on_page = _.mwl_products_on_page || {};
+              var bid = {$block.block_id|default:0};
+              var ids = {$mwl_xlsx_ids|json_encode nofilter} || [];
+              if (!Array.isArray(ids)) {
+                ids = String(ids || '').split(',').filter(Boolean).map(Number);
+              }
+              var prev = _.mwl_products_on_page[bid] || [];
+              var uniq = {};
+              prev.concat(ids).forEach(function(x){ if (x != null) uniq[x] = 1; });
+              _.mwl_products_on_page[bid] = Object.keys(uniq).map(Number);
+              $.ceEvent('trigger', 'mwl.products_on_page.updated', [bid, _.mwl_products_on_page[bid]]);
+            }(Tygh, Tygh.$));
+            </script>
+
+            {if $auth}
+                {assign var=lists value=fn_mwl_xlsx_get_lists($auth.user_id)}
+            {else}
+                {assign var=lists value=fn_mwl_xlsx_get_lists(null)}
+            {/if}
+            <div class="mwl_xlsx-control mwl_xlsx-control--category">
+                <select class="mwl_xlsx-select" data-ca-list-select-xlsx>
+                    {foreach $lists as $l}
+                        <option value="{$l.list_id}">{$l.name}</option>
+                    {/foreach}
+                    <option value="_new">+ {__("mwl_xlsx.new_list")}</option>
+                </select>
+                <input type="text" class="mwl_xlsx-new-name ty-input-text" data-ca-mwl-new-list-name style="display:none" placeholder="{__("mwl_xlsx.enter_list_name")}">
+                <button class="ty-btn" data-ca-add-all-to-mwl_xlsx data-ca-product-ids="{","|implode:$mwl_xlsx_ids}">
+                    {__("mwl_xlsx.add_all_to_wishlist")}
+                </button>
+            </div>
+        {/if}
+
+    {/if}
 {/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/manage.tpl
@@ -1,3 +1,4 @@
+{if fn_mwl_xlsx_user_can_access_lists($auth)}
 {capture name="mainbox"}
     {if $lists}
         <table class="ty-table" data-ca-mwl-lists>
@@ -53,3 +54,6 @@
     title=__("mwl_xlsx.my_lists")
     content=$smarty.capture.mainbox
 }
+{else}
+    {include file="common/no_items.tpl"}
+{/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/settings.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/settings.tpl
@@ -1,3 +1,4 @@
+{if fn_mwl_xlsx_user_can_access_lists($auth)}
 {capture name="mainbox"}
     <form action="{fn_url('mwl_xlsx.save_settings')}" method="post" class="cm-ajax">
         <div class="ty-control-group">
@@ -22,3 +23,6 @@
     title=__("mwl_xlsx.settings")
     content=$smarty.capture.mainbox
 }
+{else}
+    {include file="common/no_items.tpl"}
+{/if}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/views/mwl_xlsx/view.tpl
@@ -1,3 +1,4 @@
+{if fn_mwl_xlsx_user_can_access_lists($auth)}
 {capture name="mainbox"}
     <div class="mwl_xlsx-view-page">
         {if $products}
@@ -33,3 +34,6 @@
     title=$list.name
     content=$smarty.capture.mainbox
 }
+{else}
+    {include file="common/no_items.tpl"}
+{/if}


### PR DESCRIPTION
## Summary
- add module settings to hide price for guests, control user group access, and toggle extra list button
- enforce group restrictions in controller and templates
- document new options and provide translations

## Testing
- `composer install`
- `php -l func.php controllers/frontend/mwl_xlsx.php`

------
https://chatgpt.com/codex/tasks/task_e_68a82193ee24832c9a6a6c3abb8b1554