### PR TITLE
Add Planfix webhook, MCP sync, and admin order bindings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@
 - Limit the number of items in a media list via the **Max list items** setting (default 50).
 - Configure the Planfix origin used for deep links so orders and customers with Planfix bindings show the task number with a direct link in the admin grids.
 - Configure Planfix MCP integration parameters (endpoint, auth token, webhook Basic Auth, default direction, status filters, comment/payment sync, IP allowlist) directly from the add-on settings.
+- Accept Planfix webhooks via `dispatch=mwl_xlsx.planfix_changed_status`, apply status mapping to CS-Cart orders, persist incoming payloads, and prevent ping-pong updates.
+- Manage Planfix bindings from a dedicated tab in the order details page: create tasks via MCP, bind existing tasks, and review the full metadata/payload history for each link.
+- Push order status changes, comments, and payment summaries to Planfix through MCP while storing the latest payload snapshot and timestamp in the binding record.
 - Compact price slider labels: Display min/max values in shortened format (1,000 → 1 K / 1 тыс.) with localization support for Russian and English.
 - Yandex Metrika tracking includes `user_id` for segmentation via `userParams` when available.
 
@@ -46,6 +49,7 @@
 - `index.php?dispatch=mwl_xlsx.remove` – remove a product from a media list (POST).
 - `index.php?dispatch=mwl_xlsx.rename_list` – rename a media list (POST).
 - `index.php?dispatch=mwl_xlsx.delete_list` – remove a media list (POST).
+- `index.php?dispatch=mwl_xlsx.planfix_changed_status` – Planfix webhook for status updates (POST).
 
 ### Manual setup
 

--- a/app/addons/mwl_xlsx/addon.xml
+++ b/app/addons/mwl_xlsx/addon.xml
@@ -73,6 +73,8 @@
             `extra` TEXT NULL,
             `created_at` INT UNSIGNED NOT NULL,
             `updated_at` INT UNSIGNED NOT NULL,
+            `last_push_at` INT UNSIGNED NULL DEFAULT NULL,
+            `last_payload_out` MEDIUMTEXT NULL,
             PRIMARY KEY (`link_id`),
             UNIQUE KEY `entity_planfix` (`company_id`, `entity_type`, `entity_id`, `planfix_object_type`, `planfix_object_id`),
             KEY `planfix_object` (`planfix_object_type`, `planfix_object_id`)

--- a/app/addons/mwl_xlsx/controllers/backend/orders.post.php
+++ b/app/addons/mwl_xlsx/controllers/backend/orders.post.php
@@ -158,6 +158,15 @@ if ($mode === 'manage') {
             continue;
         }
 
+        $link['extra'] = fn_mwl_planfix_decode_link_extra($link['extra'] ?? null);
+        $payload_out = isset($link['last_payload_out']) ? $link['last_payload_out'] : '';
+        if (is_string($payload_out) && $payload_out !== '') {
+            $decoded_payload = json_decode($payload_out, true);
+            if (is_array($decoded_payload)) {
+                $link['last_payload_out_decoded'] = $decoded_payload;
+            }
+        }
+
         $link['planfix_url'] = fn_mwl_planfix_build_object_url($link, $planfix_origin);
         $planfix_links[(int) $entity_id] = $link;
     }
@@ -220,4 +229,32 @@ if ($mode === 'manage') {
     }
 
     $view->assign('mwl_xlsx_order_messages', $order_messages);
+}
+
+if ($mode === 'details' || $mode === 'update') {
+    $order_id = isset($_REQUEST['order_id']) ? (int) $_REQUEST['order_id'] : 0;
+
+    if ($order_id) {
+        $company_id = (int) db_get_field('SELECT company_id FROM ?:orders WHERE order_id = ?i', $order_id);
+
+        $link_repository = fn_mwl_planfix_link_repository();
+        $link = $link_repository->findByEntity($company_id, 'order', $order_id);
+
+        if ($link) {
+            $link['extra'] = fn_mwl_planfix_decode_link_extra($link['extra'] ?? null);
+            $payload_out = isset($link['last_payload_out']) ? $link['last_payload_out'] : '';
+            if (is_string($payload_out) && $payload_out !== '') {
+                $decoded_payload = json_decode($payload_out, true);
+                if (is_array($decoded_payload)) {
+                    $link['last_payload_out_decoded'] = $decoded_payload;
+                }
+            }
+            $link['planfix_url'] = fn_mwl_planfix_build_object_url(
+                $link,
+                (string) Registry::get('addons.mwl_xlsx.planfix_origin')
+            );
+        }
+
+        Tygh::$app['view']->assign('mwl_planfix_order_link', $link);
+    }
 }

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -13,6 +13,11 @@ use Google\Service\Sheets\Spreadsheet;
 use Google\Service\Sheets\ValueRange;
 use Google\Service\Sheets\BatchUpdateSpreadsheetRequest;
 
+if ($mode === 'planfix_changed_status') {
+    fn_mwl_planfix_handle_planfix_status_webhook();
+    return [CONTROLLER_STATUS_NO_CONTENT];
+}
+
 if (!fn_mwl_xlsx_user_can_access_lists($auth)) {
     return [CONTROLLER_STATUS_DENIED];
 }

--- a/app/addons/mwl_xlsx/init.php
+++ b/app/addons/mwl_xlsx/init.php
@@ -26,7 +26,8 @@ fn_register_hooks(
     // 'init_user_session_data_post',
     'before_dispatch',
     'get_product_filter_fields',
-    'init_templater_post'
+    'init_templater_post',
+    'change_order_status_post'
 );
 
 /**

--- a/app/addons/mwl_xlsx/src/Planfix/LinkRepository.php
+++ b/app/addons/mwl_xlsx/src/Planfix/LinkRepository.php
@@ -25,9 +25,33 @@ class LinkRepository
             'extra'              => $extra ? json_encode($extra, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : null,
             'created_at'         => TIME,
             'updated_at'         => TIME,
+            'last_push_at'       => null,
+            'last_payload_out'   => null,
         ];
 
         return (int) $this->db->query('REPLACE INTO ?:mwl_planfix_links ?e', $data);
+    }
+
+    public function update(int $link_id, array $data): void
+    {
+        if (!$data) {
+            return;
+        }
+
+        if (array_key_exists('extra', $data)) {
+            $extra = $data['extra'];
+            if (is_array($extra)) {
+                $data['extra'] = $extra ? json_encode($extra, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : null;
+            } elseif ($extra === '') {
+                $data['extra'] = null;
+            }
+        }
+
+        if (!isset($data['updated_at'])) {
+            $data['updated_at'] = TIME;
+        }
+
+        $this->db->query('UPDATE ?:mwl_planfix_links SET ?u WHERE link_id = ?i', $data, $link_id);
     }
 
     public function findByEntity(int $company_id, string $entity_type, int $entity_id): ?array

--- a/app/addons/mwl_xlsx/src/Planfix/McpClient.php
+++ b/app/addons/mwl_xlsx/src/Planfix/McpClient.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Planfix;
+
+use Tygh\Http;
+
+class McpClient
+{
+    /** @var string */
+    private $endpoint;
+
+    /** @var string */
+    private $authToken;
+
+    /** @var int|null */
+    private $lastStatusCode = null;
+
+    public function __construct(string $endpoint, string $authToken)
+    {
+        $this->endpoint = rtrim($endpoint, '/');
+        $this->authToken = $authToken;
+    }
+
+    public function getLastStatusCode(): ?int
+    {
+        return $this->lastStatusCode;
+    }
+
+    public function updateSaleStatus(array $payload): array
+    {
+        return $this->request('update_sale_status', $payload);
+    }
+
+    public function appendSaleComment(array $payload): array
+    {
+        return $this->request('append_sale_comment', $payload);
+    }
+
+    public function registerSalePayment(array $payload): array
+    {
+        return $this->request('register_sale_payment', $payload);
+    }
+
+    public function createTask(array $payload): array
+    {
+        return $this->request('create_task', $payload);
+    }
+
+    public function bindTask(array $payload): array
+    {
+        return $this->request('bind_task', $payload);
+    }
+
+    private function request(string $path, array $payload): array
+    {
+        if ($this->endpoint === '') {
+            $this->lastStatusCode = null;
+
+            return [
+                'success' => false,
+                'http_code' => 0,
+                'body' => null,
+                'data' => null,
+                'error' => 'Empty MCP endpoint',
+            ];
+        }
+
+        $url = $this->endpoint . '/' . ltrim($path, '/');
+
+        $headers = [
+            'Content-Type: application/json; charset=utf-8',
+        ];
+
+        if ($this->authToken !== '') {
+            $headers[] = 'Authorization: Bearer ' . $this->authToken;
+        }
+
+        $options = [
+            'headers' => $headers,
+            'timeout' => 15,
+        ];
+
+        $response = Http::post(
+            $url,
+            json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            $options
+        );
+
+        $status = Http::getStatus();
+        $this->lastStatusCode = is_int($status) ? $status : null;
+
+        $decoded = json_decode((string) $response, true);
+
+        return [
+            'success' => $status >= 200 && $status < 300,
+            'http_code' => $status,
+            'body' => $response,
+            'data' => is_array($decoded) ? $decoded : null,
+        ];
+    }
+}

--- a/design/backend/templates/addons/mwl_xlsx/hooks/orders/tabs_content.post.tpl
+++ b/design/backend/templates/addons/mwl_xlsx/hooks/orders/tabs_content.post.tpl
@@ -1,0 +1,136 @@
+{if $order_info.order_id}
+    {assign var="planfix_link" value=$mwl_planfix_order_link|default:[]}
+    {assign var="planfix_meta" value=$planfix_link.extra.planfix_meta|default:[]}
+    {assign var="last_incoming" value=$planfix_link.extra.last_incoming_status|default:[]}
+    {assign var="last_outgoing" value=$planfix_link.extra.last_outgoing_status|default:[]}
+    {assign var="last_payload_in" value=$planfix_link.extra.last_planfix_payload_in|default:[]}
+    {assign var="has_link" value=($planfix_link.planfix_object_id|default:'') != ''}
+    <div id="content_tab_mwl_planfix" class="hidden">
+        <div class="well well-small">
+            <div class="control-group">
+                <label class="control-label">{__("mwl_xlsx.planfix_linked_task")}</label>
+                <div class="controls">
+                    {if $planfix_link.planfix_object_id|default:''}
+                        {if $planfix_link.planfix_url|default:''}
+                            <a href="{$planfix_link.planfix_url|escape:'html'}" target="_blank" rel="noopener noreferrer">
+                                {$planfix_link.planfix_object_id|escape}
+                            </a>
+                        {else}
+                            {$planfix_link.planfix_object_id|escape}
+                        {/if}
+                    {else}
+                        <span class="muted">{__("mwl_xlsx.planfix_no_link")}</span>
+                    {/if}
+                </div>
+            </div>
+
+            <div class="control-group">
+                <label class="control-label">{__("mwl_xlsx.planfix_actions")}</label>
+                <div class="controls">
+                    <form action="{"mwl_xlsx.planfix_create_task"|fn_url}" method="post" class="form-inline">
+                        <input type="hidden" name="dispatch" value="mwl_xlsx.planfix_create_task" />
+                        <input type="hidden" name="order_id" value="{$order_info.order_id}" />
+                        <input type="hidden" name="return_url" value="{$config.current_url|fn_url}" />
+                        {include file="buttons/button.tpl"
+                            but_role="submit"
+                            but_meta="btn btn-primary"
+                            but_text=__("mwl_xlsx.planfix_button_create")
+                            but_disabled=$has_link
+                        }
+                    </form>
+
+                    <form action="{"mwl_xlsx.planfix_bind_task"|fn_url}" method="post" class="form-inline">
+                        <input type="hidden" name="dispatch" value="mwl_xlsx.planfix_bind_task" />
+                        <input type="hidden" name="order_id" value="{$order_info.order_id}" />
+                        <input type="hidden" name="planfix_object_type" value="task" />
+                        <input type="hidden" name="return_url" value="{$config.current_url|fn_url}" />
+                        <div class="input-append">
+                            <input type="text" class="input-medium" name="planfix_task_id" placeholder="{__("mwl_xlsx.planfix_placeholder_task_id")}" value="" />
+                            {include file="buttons/button.tpl"
+                                but_role="submit"
+                                but_meta="btn"
+                                but_text=__("mwl_xlsx.planfix_button_bind")
+                            }
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <h4 class="subheader">{__("mwl_xlsx.planfix_metadata_heading")}</h4>
+        <table class="table table-middle">
+            <tbody>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_status_id")}</th>
+                <td>{$planfix_meta.status_id|default:''|escape}</td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_status_name")}</th>
+                <td>{$planfix_meta.status_name|default:''|escape}</td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_status_type")}</th>
+                <td>{$planfix_meta.status_type|default:''|escape}</td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_direction")}</th>
+                <td>{$planfix_meta.direction|default:''|escape}</td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_last_status_from_planfix")}</th>
+                <td>
+                    {if $last_incoming.status_name|default:''}
+                        {$last_incoming.status_name|escape}
+                        <small class="muted">{$last_incoming.received_at|default:0|date_format:"`$settings.Appearance.date_format` `$settings.Appearance.time_format`"}</small>
+                    {else}
+                        <span class="muted">{__("mwl_xlsx.planfix_no_data")}</span>
+                    {/if}
+                </td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_last_status_from_cs")}</th>
+                <td>
+                    {if $last_outgoing.status_to|default:''}
+                        {$last_outgoing.status_to|escape}
+                        <small class="muted">{$last_outgoing.pushed_at|default:0|date_format:"`$settings.Appearance.date_format` `$settings.Appearance.time_format`"}</small>
+                    {else}
+                        <span class="muted">{__("mwl_xlsx.planfix_no_data")}</span>
+                    {/if}
+                </td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_last_push_at")}</th>
+                <td>
+                    {if $planfix_link.last_push_at|default:0}
+                        {$planfix_link.last_push_at|date_format:"`$settings.Appearance.date_format` `$settings.Appearance.time_format`"}
+                    {else}
+                        <span class="muted">{__("mwl_xlsx.planfix_no_data")}</span>
+                    {/if}
+                </td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_last_payload_out")}</th>
+                <td>
+                    {if $planfix_link.last_payload_out_decoded|default:false}
+                        <pre class="pre">{$planfix_link.last_payload_out_decoded|@print_r:true}</pre>
+                    {elseif $planfix_link.last_payload_out|default:''}
+                        <pre class="pre">{$planfix_link.last_payload_out|escape}</pre>
+                    {else}
+                        <span class="muted">{__("mwl_xlsx.planfix_no_data")}</span>
+                    {/if}
+                </td>
+            </tr>
+            <tr>
+                <th>{__("mwl_xlsx.planfix_last_payload_in")}</th>
+                <td>
+                    {if $last_payload_in.payload|default:false}
+                        <pre class="pre">{$last_payload_in.payload|@print_r:true}</pre>
+                    {else}
+                        <span class="muted">{__("mwl_xlsx.planfix_no_data")}</span>
+                    {/if}
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+{/if}

--- a/design/backend/templates/addons/mwl_xlsx/hooks/orders/tabs_extra.post.tpl
+++ b/design/backend/templates/addons/mwl_xlsx/hooks/orders/tabs_extra.post.tpl
@@ -1,0 +1,5 @@
+{if $order_info.order_id}
+    <li id="tab_mwl_planfix" class="cm-js {if $selected_section == "mwl_planfix"}cm-active{/if}">
+        <a>{__("mwl_xlsx.planfix_tab_title")}</a>
+    </li>
+{/if}

--- a/var/langs/en/addons/mwl_xlsx.po
+++ b/var/langs/en/addons/mwl_xlsx.po
@@ -316,6 +316,106 @@ msgctxt "Languages::mwl_xlsx.planfix_task"
 msgid "Planfix task"
 msgstr "Planfix task"
 
+msgctxt "Languages::mwl_xlsx.planfix_tab_title"
+msgid "Planfix"
+msgstr "Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_button_create"
+msgid "Create Planfix task"
+msgstr "Create Planfix task"
+
+msgctxt "Languages::mwl_xlsx.planfix_button_bind"
+msgid "Bind existing task"
+msgstr "Bind existing task"
+
+msgctxt "Languages::mwl_xlsx.planfix_placeholder_task_id"
+msgid "Task ID"
+msgstr "Task ID"
+
+msgctxt "Languages::mwl_xlsx.planfix_metadata_heading"
+msgid "Planfix metadata"
+msgstr "Planfix metadata"
+
+msgctxt "Languages::mwl_xlsx.planfix_status_id"
+msgid "Status ID"
+msgstr "Status ID"
+
+msgctxt "Languages::mwl_xlsx.planfix_status_name"
+msgid "Status name"
+msgstr "Status name"
+
+msgctxt "Languages::mwl_xlsx.planfix_status_type"
+msgid "Status type"
+msgstr "Status type"
+
+msgctxt "Languages::mwl_xlsx.planfix_direction"
+msgid "Direction"
+msgstr "Direction"
+
+msgctxt "Languages::mwl_xlsx.planfix_linked_task"
+msgid "Linked Planfix task"
+msgstr "Linked Planfix task"
+
+msgctxt "Languages::mwl_xlsx.planfix_actions"
+msgid "Actions"
+msgstr "Actions"
+
+msgctxt "Languages::mwl_xlsx.planfix_no_link"
+msgid "No Planfix task linked"
+msgstr "No Planfix task linked"
+
+msgctxt "Languages::mwl_xlsx.planfix_no_data"
+msgid "No data"
+msgstr "No data"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_status_from_planfix"
+msgid "Last status from Planfix"
+msgstr "Last status from Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_status_from_cs"
+msgid "Last status sent to Planfix"
+msgstr "Last status sent to Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_push_at"
+msgid "Last push time"
+msgstr "Last push time"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_payload_out"
+msgid "Last payload (outgoing)"
+msgstr "Last payload (outgoing)"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_payload_in"
+msgid "Last payload (incoming)"
+msgstr "Last payload (incoming)"
+
+msgctxt "Languages::mwl_xlsx.planfix_task_created"
+msgid "Planfix task [id] was created"
+msgstr "Planfix task [id] was created"
+
+msgctxt "Languages::mwl_xlsx.planfix_task_bound"
+msgid "Planfix task [id] was bound to the order"
+msgstr "Planfix task [id] was bound to the order"
+
+msgctxt "Languages::mwl_xlsx.planfix_task_already_bound"
+msgid "Planfix task is already bound to order #[order_id]"
+msgstr "Planfix task is already bound to order #[order_id]"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_order_not_found"
+msgid "Order was not found"
+msgstr "Order was not found"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_mcp_request"
+msgid "Planfix MCP request failed"
+msgstr "Planfix MCP request failed"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_task_id_missing"
+msgid "Planfix task ID is missing"
+msgstr "Planfix task ID is missing"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_unknown"
+msgid "Planfix integration error"
+msgstr "Planfix integration error"
+
 msgctxt "SettingsOptions::mwl_xlsx::planfix_origin"
 msgid "Planfix origin"
 msgstr "Planfix origin"

--- a/var/langs/ru/addons/mwl_xlsx.po
+++ b/var/langs/ru/addons/mwl_xlsx.po
@@ -290,6 +290,106 @@ msgctxt "Languages::mwl_xlsx.planfix_task"
 msgid "Planfix task"
 msgstr "Задача Planfix"
 
+msgctxt "Languages::mwl_xlsx.planfix_tab_title"
+msgid "Planfix"
+msgstr "Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_button_create"
+msgid "Create Planfix task"
+msgstr "Создать задачу в Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_button_bind"
+msgid "Bind existing task"
+msgstr "Привязать существующую задачу"
+
+msgctxt "Languages::mwl_xlsx.planfix_placeholder_task_id"
+msgid "Task ID"
+msgstr "ID задачи"
+
+msgctxt "Languages::mwl_xlsx.planfix_metadata_heading"
+msgid "Planfix metadata"
+msgstr "Метаданные Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_status_id"
+msgid "Status ID"
+msgstr "ID статуса"
+
+msgctxt "Languages::mwl_xlsx.planfix_status_name"
+msgid "Status name"
+msgstr "Название статуса"
+
+msgctxt "Languages::mwl_xlsx.planfix_status_type"
+msgid "Status type"
+msgstr "Тип статуса"
+
+msgctxt "Languages::mwl_xlsx.planfix_direction"
+msgid "Direction"
+msgstr "Направление"
+
+msgctxt "Languages::mwl_xlsx.planfix_linked_task"
+msgid "Linked Planfix task"
+msgstr "Привязанная задача Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_actions"
+msgid "Actions"
+msgstr "Действия"
+
+msgctxt "Languages::mwl_xlsx.planfix_no_link"
+msgid "No Planfix task linked"
+msgstr "Задача не привязана"
+
+msgctxt "Languages::mwl_xlsx.planfix_no_data"
+msgid "No data"
+msgstr "Нет данных"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_status_from_planfix"
+msgid "Last status from Planfix"
+msgstr "Последний статус из Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_status_from_cs"
+msgid "Last status sent to Planfix"
+msgstr "Последний статус, отправленный в Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_push_at"
+msgid "Last push time"
+msgstr "Время последней отправки"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_payload_out"
+msgid "Last payload (outgoing)"
+msgstr "Последний исходящий payload"
+
+msgctxt "Languages::mwl_xlsx.planfix_last_payload_in"
+msgid "Last payload (incoming)"
+msgstr "Последний входящий payload"
+
+msgctxt "Languages::mwl_xlsx.planfix_task_created"
+msgid "Planfix task [id] was created"
+msgstr "Задача Planfix [id] создана"
+
+msgctxt "Languages::mwl_xlsx.planfix_task_bound"
+msgid "Planfix task [id] was bound to the order"
+msgstr "Задача Planfix [id] привязана к заказу"
+
+msgctxt "Languages::mwl_xlsx.planfix_task_already_bound"
+msgid "Planfix task is already bound to order #[order_id]"
+msgstr "Задача Planfix уже привязана к заказу #[order_id]"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_order_not_found"
+msgid "Order was not found"
+msgstr "Заказ не найден"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_mcp_request"
+msgid "Planfix MCP request failed"
+msgstr "Ошибка запроса к Planfix MCP"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_task_id_missing"
+msgid "Planfix task ID is missing"
+msgstr "Не указан ID задачи Planfix"
+
+msgctxt "Languages::mwl_xlsx.planfix_error_unknown"
+msgid "Planfix integration error"
+msgstr "Ошибка интеграции с Planfix"
+
 msgctxt "SettingsOptions::mwl_xlsx::planfix_origin"
 msgid "Planfix origin"
 msgstr "Адрес Planfix"


### PR DESCRIPTION
## Summary
- add an authenticated Planfix webhook controller that records incoming payloads, applies status mappings to orders, and avoids status ping-pong
- push order status/comment/payment changes to Planfix MCP via a new client while tracking last outbound payload metadata
- expose Planfix task management on the order details screen with create/bind actions, metadata display, schema/language updates, and documentation

## Testing
- php -l app/addons/mwl_xlsx/func.php
- php -l app/addons/mwl_xlsx/init.php
- php -l app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
- php -l app/addons/mwl_xlsx/src/Planfix/LinkRepository.php
- php -l app/addons/mwl_xlsx/src/Planfix/McpClient.php
- php -l app/addons/mwl_xlsx/controllers/backend/mwl_xlsx.php
- php -l app/addons/mwl_xlsx/controllers/backend/orders.post.php

------
https://chatgpt.com/codex/tasks/task_e_68dfb619bbf8832c80a1512e0112ea19