### PR TITLE
Automatically create Planfix task for new orders

### DIFF
--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -798,6 +798,14 @@ function fn_mwl_xlsx_change_order_status_post(
         return;
     }
 
+    if (!is_array($order_info) || !$order_info) {
+        $order_info = fn_get_order_info($order_id, false, true, true, false);
+
+        if (!$order_info) {
+            return;
+        }
+    }
+
     if (fn_mwl_planfix_should_skip_status_push($order_id)) {
         return;
     }
@@ -808,7 +816,7 @@ function fn_mwl_xlsx_change_order_status_post(
     $link = $link_repository->findByEntity($company_id, 'order', $order_id);
 
     if (!$link || empty($link['planfix_object_id'])) {
-        $creation_result = fn_mwl_planfix_create_task_for_order($order_id, $order_info);
+        $creation_result = fn_mwl_planfix_create_task_for_order($order_id);
 
         if (empty($creation_result['success'])) {
             return;

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -808,7 +808,17 @@ function fn_mwl_xlsx_change_order_status_post(
     $link = $link_repository->findByEntity($company_id, 'order', $order_id);
 
     if (!$link || empty($link['planfix_object_id'])) {
-        return;
+        $creation_result = fn_mwl_planfix_create_task_for_order($order_id, $order_info);
+
+        if (empty($creation_result['success'])) {
+            return;
+        }
+
+        $link = $creation_result['link'] ?? $link_repository->findByEntity($company_id, 'order', $order_id);
+
+        if (!$link || empty($link['planfix_object_id'])) {
+            return;
+        }
     }
 
     $planfix_object_id = (string) $link['planfix_object_id'];

--- a/app/addons/mwl_xlsx/func.php
+++ b/app/addons/mwl_xlsx/func.php
@@ -798,14 +798,6 @@ function fn_mwl_xlsx_change_order_status_post(
         return;
     }
 
-    if (!is_array($order_info) || !$order_info) {
-        $order_info = fn_get_order_info($order_id, false, true, true, false);
-
-        if (!$order_info) {
-            return;
-        }
-    }
-
     if (fn_mwl_planfix_should_skip_status_push($order_id)) {
         return;
     }


### PR DESCRIPTION
## Summary
- create a Planfix task from the order status change hook when no link exists yet
- reuse the returned link so subsequent status updates can push data to Planfix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e028c2268c832c85971cf19db99648