### PR TITLE
Refactor Planfix integration and add tests

### DIFF
--- a/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Planfix/IntegrationSettings.php
+++ b/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Planfix/IntegrationSettings.php
@@ -32,6 +32,23 @@ class IntegrationSettings
     /** @var array */
     protected $webhook_allowlist_ips = [];
 
+    public static function fromArray(array $data): self
+    {
+        $instance = new self();
+
+        $instance->mcp_endpoint = self::normalizeString($data['mcp_endpoint'] ?? '');
+        $instance->mcp_auth_token = self::normalizeString($data['mcp_auth_token'] ?? '');
+        $instance->webhook_basic_login = self::normalizeString($data['webhook_basic_login'] ?? '');
+        $instance->webhook_basic_password = self::normalizeString($data['webhook_basic_password'] ?? '');
+        $instance->direction_default = self::normalizeString($data['direction_default'] ?? '');
+        $instance->auto_task_statuses = self::normalizeList($data['auto_task_statuses'] ?? []);
+        $instance->sync_comments = self::normalizeFlag($data['sync_comments'] ?? '');
+        $instance->sync_payments = self::normalizeFlag($data['sync_payments'] ?? '');
+        $instance->webhook_allowlist_ips = self::normalizeList($data['webhook_allowlist_ips'] ?? []);
+
+        return $instance;
+    }
+
     public static function fromRegistry(): self
     {
         $instance = new self();

--- a/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Planfix/PlanfixService.php
+++ b/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Planfix/PlanfixService.php
@@ -1,0 +1,589 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Planfix;
+
+use Tygh\Addons\MwlXlsx\Telegram\TelegramService;
+use Tygh\Registry;
+
+class PlanfixService
+{
+    /** @var LinkRepository */
+    private $linkRepository;
+
+    /** @var McpClient */
+    private $client;
+
+    /** @var IntegrationSettings */
+    private $settings;
+
+    /** @var TelegramService */
+    private $telegramService;
+
+    /** @var callable */
+    private $orderFetcher;
+
+    /** @var callable */
+    private $userFetcher;
+
+    /** @var callable */
+    private $orderUrlBuilder;
+
+    /** @var callable */
+    private $orderStatusFetcher;
+
+    /** @var callable */
+    private $orderStatusUpdater;
+
+    public function __construct(
+        LinkRepository $linkRepository,
+        McpClient $client,
+        IntegrationSettings $settings,
+        TelegramService $telegramService,
+        callable $orderFetcher = null,
+        callable $userFetcher = null,
+        callable $orderUrlBuilder = null,
+        callable $orderStatusFetcher = null,
+        callable $orderStatusUpdater = null
+    ) {
+        $this->linkRepository = $linkRepository;
+        $this->client = $client;
+        $this->settings = $settings;
+        $this->telegramService = $telegramService;
+        $this->orderFetcher = $orderFetcher ?: static function (int $order_id): array {
+            return fn_get_order_info($order_id, false, true, true, false) ?: [];
+        };
+        $this->userFetcher = $userFetcher ?: static function (int $user_id): array {
+            return fn_get_user_info($user_id) ?: [];
+        };
+        $this->orderUrlBuilder = $orderUrlBuilder ?: static function (int $order_id): string {
+            if (!$order_id) {
+                return '';
+            }
+
+            return fn_url('orders.details?order_id=' . $order_id, 'A', 'current', defined('CART_LANGUAGE') ? CART_LANGUAGE : 'en', true);
+        };
+        $this->orderStatusFetcher = $orderStatusFetcher ?: static function (int $order_id): string {
+            $status = db_get_field('SELECT status FROM ?:orders WHERE order_id = ?i', $order_id);
+
+            return (string) ($status ?? '');
+        };
+        $this->orderStatusUpdater = $orderStatusUpdater ?: static function (int $order_id, string $status_to, string $status_from): bool {
+            $result = fn_change_order_status($order_id, $status_to, $status_from);
+
+            return $result !== false;
+        };
+    }
+
+    public function getSettings(): IntegrationSettings
+    {
+        return $this->settings;
+    }
+
+    public function getMcpClient(): McpClient
+    {
+        return $this->client;
+    }
+
+    public function getLinkRepository(): LinkRepository
+    {
+        return $this->linkRepository;
+    }
+
+    public function buildObjectUrl(array $link, ?string $origin = null): string
+    {
+        $planfix_object_id = isset($link['planfix_object_id']) ? (string) $link['planfix_object_id'] : '';
+
+        if ($planfix_object_id === '') {
+            return '';
+        }
+
+        if ($origin === null) {
+            $origin = (string) Registry::get('addons.mwl_xlsx.planfix_origin');
+        }
+
+        $origin = trim($origin);
+
+        if ($origin === '') {
+            return '';
+        }
+
+        $origin = rtrim($origin, '/');
+        $type = isset($link['planfix_object_type']) ? trim((string) $link['planfix_object_type']) : '';
+
+        if ($type !== '') {
+            $origin .= '/' . ltrim($type, '/');
+        }
+
+        return $origin . '/' . rawurlencode($planfix_object_id);
+    }
+
+    public function decodeLinkExtra($extra): array
+    {
+        if (is_array($extra)) {
+            return $extra;
+        }
+
+        if (is_string($extra) && $extra !== '') {
+            $decoded = json_decode($extra, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
+    public function updateLinkExtra(array $link, array $extraUpdates, array $additionalFields = []): void
+    {
+        if (empty($link['link_id'])) {
+            return;
+        }
+
+        $extra = $this->decodeLinkExtra($link['extra'] ?? null);
+
+        foreach ($extraUpdates as $key => $value) {
+            if ($value === null) {
+                unset($extra[$key]);
+            } else {
+                $extra[$key] = $value;
+            }
+        }
+
+        $data = ['extra' => $extra];
+
+        if ($additionalFields) {
+            $data = array_merge($data, $additionalFields);
+        }
+
+        $this->linkRepository->update((int) $link['link_id'], $data);
+    }
+
+    public function buildSellTaskPayload(array $order_info): array
+    {
+        $order_id = isset($order_info['order_id']) ? (int) $order_info['order_id'] : 0;
+        $company_id = isset($order_info['company_id']) ? (int) $order_info['company_id'] : 0;
+        $primary_currency = isset($order_info['primary_currency'])
+            ? (string) $order_info['primary_currency']
+            : (defined('CART_PRIMARY_CURRENCY') ? CART_PRIMARY_CURRENCY : 'RUB');
+        $secondary_currency = isset($order_info['secondary_currency']) ? (string) $order_info['secondary_currency'] : '';
+        $currency_code = $secondary_currency !== '' ? $secondary_currency : ((string) ($order_info['currency'] ?? $primary_currency));
+
+        $products = isset($order_info['products']) && is_array($order_info['products'])
+            ? $order_info['products']
+            : [];
+
+        $first_product_name = '';
+        foreach ($products as $item) {
+            if (!empty($item['product'])) {
+                $first_product_name = (string) $item['product'];
+                break;
+            }
+        }
+
+        if ($first_product_name === '') {
+            $first_product_name = $order_id
+                ? sprintf('#%s', fn_mwl_planfix_format_order_id($order_id))
+                : __('order');
+        }
+
+        $task_name = sprintf('Продажа %s на pressfinity.com', $first_product_name);
+
+        $lines = [];
+        foreach ($products as $item) {
+            $product_name = (string) ($item['product'] ?? '');
+            if ($product_name === '' && !empty($item['product_id'])) {
+                $product_name = sprintf('#%d', (int) $item['product_id']);
+            }
+
+            $amount = isset($item['amount']) ? (int) $item['amount'] : 0;
+            if ($amount <= 0) {
+                $amount = 1;
+            }
+
+            $subtotal = isset($item['subtotal']) ? (float) $item['subtotal'] : 0.0;
+            $price = number_format($subtotal, 2, '.', ' ');
+            $price = rtrim(rtrim($price, '0'), '.');
+            if ($price === '') {
+                $price = '0';
+            }
+
+            $line = sprintf('- %s ×%d, %s', $product_name, $amount, $price);
+
+            if ($currency_code !== '') {
+                $line .= ' ' . $currency_code;
+            }
+
+            $lines[] = $line;
+        }
+
+        $description = implode("\n", $lines);
+        $order_url = $order_id ? call_user_func($this->orderUrlBuilder, $order_id) : '';
+
+        if ($order_url !== '') {
+            if ($description !== '') {
+                $description .= "\n\n";
+            }
+
+            $description .= sprintf('Ссылка на заказ: %s', $order_url);
+        }
+
+        if ($description === '' && $order_id) {
+            $description = sprintf('Заказ #%s', fn_mwl_planfix_format_order_id($order_id));
+        }
+
+        $customer = [
+            'name'  => trim(((string) ($order_info['firstname'] ?? '')) . ' ' . ((string) ($order_info['lastname'] ?? ''))),
+            'email' => (string) ($order_info['email'] ?? ''),
+            'phone' => (string) ($order_info['phone'] ?? ''),
+        ];
+
+        $customer = array_filter($customer, static function ($value) {
+            return $value !== '';
+        });
+
+        $order_number = $order_id ? fn_mwl_planfix_format_order_id($order_id) : '';
+        $user_id = isset($order_info['user_id']) ? (int) $order_info['user_id'] : 0;
+        $user_data = isset($order_info['user_data']) && is_array($order_info['user_data'])
+            ? $order_info['user_data']
+            : call_user_func($this->userFetcher, $user_id);
+
+        $payload = [
+            'name'          => $task_name,
+            'agency'        => (string) ($user_data['company'] ?? ''),
+            'email'         => (string) ($order_info['email'] ?? ''),
+            'employee_name' => trim(((string) ($user_data['firstname'] ?? '')) . ' ' . ((string) ($user_data['lastname'] ?? ''))),
+            'telegram'      => $this->telegramService->resolveUserTelegram($user_id, $user_data),
+            'description'   => $description,
+            'order_id'      => $order_id ? (string) $order_id : '',
+            'order_number'  => (string) $order_number,
+            'order_url'     => $order_url,
+            'company_id'    => $company_id,
+            'direction'     => $this->settings->getDirectionDefault(),
+            'status'        => (string) ($order_info['status'] ?? ''),
+            'total'         => isset($order_info['total']) ? (float) $order_info['total'] : 0.0,
+            'currency'      => $currency_code,
+        ];
+
+        if ($customer) {
+            $payload['customer'] = $customer;
+        }
+
+        if (!empty($order_info['planfix_meta']) && is_array($order_info['planfix_meta'])) {
+            $payload['planfix_meta'] = $order_info['planfix_meta'];
+        }
+
+        return $payload;
+    }
+
+    public function createTaskForOrder(int $order_id, array $order_info = []): array
+    {
+        if (!$order_info) {
+            $order_info = call_user_func($this->orderFetcher, $order_id);
+        }
+
+        if (!$order_info) {
+            return [
+                'success' => false,
+                'message' => __('mwl_xlsx.planfix_error_order_not_found'),
+            ];
+        }
+
+        $payload = $this->buildSellTaskPayload($order_info);
+        $company_id = isset($order_info['company_id']) ? (int) $order_info['company_id'] : 0;
+
+        $response = $this->client->createTask($payload);
+
+        if (empty($response['success'])) {
+            return [
+                'success' => false,
+                'message' => __('mwl_xlsx.planfix_error_mcp_request'),
+                'response' => $response,
+            ];
+        }
+
+        $data = isset($response['data']) && is_array($response['data']) ? $response['data'] : [];
+        $planfix_task_id = (string) ($data['taskId'] ?? '');
+        $planfix_task_url = (string) ($data['url'] ?? '');
+
+        if ($planfix_task_id === '') {
+            return [
+                'success' => false,
+                'message' => __('mwl_xlsx.planfix_error_task_id_missing'),
+                'response' => $response,
+            ];
+        }
+
+        $planfix_object_type = (string) ($data['planfix_object_type'] ?? 'task');
+
+        $extra = [
+            'planfix_meta' => [
+                'status_id'   => isset($data['status_id']) ? (string) $data['status_id'] : '',
+                'direction'   => isset($data['direction']) ? (string) $data['direction'] : $payload['direction'],
+            ],
+            'created_via' => 'planfix_create_sell_task',
+            'created_at'  => TIME,
+        ];
+
+        $this->linkRepository->upsert($company_id, 'order', $order_id, $planfix_object_type, $planfix_task_id, $extra);
+        $link = $this->linkRepository->findByEntity($company_id, 'order', $order_id);
+
+        if ($link) {
+            $this->updateLinkExtra(
+                $link,
+                [],
+                [
+                    'last_push_at'     => TIME,
+                    'last_payload_out' => json_encode(['planfix_create_sell_task' => $payload], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                ]
+            );
+
+            $link = $this->linkRepository->findByEntity($company_id, 'order', $order_id);
+            if (is_array($link)) {
+                $planfix_origin = (string) Registry::get('addons.mwl_xlsx.planfix_origin');
+                $link['planfix_url'] = $this->buildObjectUrl($link, $planfix_origin);
+                if ($planfix_task_url !== '' && empty($link['planfix_url'])) {
+                    $link['planfix_url'] = $planfix_task_url;
+                }
+            }
+        }
+
+        return [
+            'success'  => true,
+            'message'  => __('mwl_xlsx.planfix_task_created', ['[id]' => $planfix_task_id]),
+            'link'     => $link,
+            'response' => $response,
+        ];
+    }
+
+    public function bindTaskToOrder(int $order_id, int $company_id, string $planfix_task_id, string $planfix_object_type = 'task', array $meta = []): array
+    {
+        $planfix_task_id = trim($planfix_task_id);
+
+        if ($planfix_task_id === '') {
+            return [
+                'success' => false,
+                'message' => __('mwl_xlsx.planfix_error_task_id_missing'),
+            ];
+        }
+
+        $planfix_object_type = $planfix_object_type !== '' ? $planfix_object_type : 'task';
+        $existing = $this->linkRepository->findByPlanfix($planfix_object_type, $planfix_task_id, $company_id ?: null);
+
+        if ($existing && (int) $existing['entity_id'] !== $order_id) {
+            return [
+                'success' => false,
+                'message' => __('mwl_xlsx.planfix_task_already_bound', ['[order_id]' => (int) $existing['entity_id']]),
+            ];
+        }
+
+        $extra = [
+            'bound_manually' => TIME,
+        ];
+
+        if (isset($meta['planfix_meta']) && is_array($meta['planfix_meta'])) {
+            $extra['planfix_meta'] = $meta['planfix_meta'];
+            unset($meta['planfix_meta']);
+        }
+
+        $extra = array_merge($extra, $meta);
+
+        $this->linkRepository->upsert($company_id, 'order', $order_id, $planfix_object_type, $planfix_task_id, $extra);
+        $link = $this->linkRepository->findByEntity($company_id, 'order', $order_id);
+
+        if ($link) {
+            $link['planfix_url'] = $this->buildObjectUrl($link);
+        }
+
+        return [
+            'success' => true,
+            'message' => __('mwl_xlsx.planfix_task_bound', ['[id]' => $planfix_task_id]),
+            'link'    => $link,
+        ];
+    }
+
+    public function recordStatusSkip(int $order_id): void
+    {
+        $skip_orders = Registry::get('mwl_xlsx.planfix_status.skip_orders');
+        if (!is_array($skip_orders)) {
+            $skip_orders = [];
+        }
+
+        $skip_orders[$order_id] = TIME;
+        Registry::set('mwl_xlsx.planfix_status.skip_orders', $skip_orders);
+    }
+
+    public function consumeStatusSkip(int $order_id): bool
+    {
+        $skip_orders = Registry::get('mwl_xlsx.planfix_status.skip_orders');
+        if (!is_array($skip_orders) || !isset($skip_orders[$order_id])) {
+            return false;
+        }
+
+        unset($skip_orders[$order_id]);
+        Registry::set('mwl_xlsx.planfix_status.skip_orders', $skip_orders);
+
+        return true;
+    }
+
+    public function syncOrderStatus(int $order_id, string $status_to, string $status_from, array $order_info): void
+    {
+        $order_id = (int) $order_id;
+        if (!$order_id) {
+            return;
+        }
+
+        if ($this->consumeStatusSkip($order_id)) {
+            return;
+        }
+
+        $company_id = isset($order_info['company_id']) ? (int) $order_info['company_id'] : 0;
+        $link = $this->linkRepository->findByEntity($company_id, 'order', $order_id);
+
+        if (!$link || empty($link['planfix_object_id'])) {
+            $creation_result = $this->createTaskForOrder($order_id, $order_info);
+            if (empty($creation_result['success'])) {
+                return;
+            }
+
+            $link = $creation_result['link'] ?? $this->linkRepository->findByEntity($company_id, 'order', $order_id);
+            if (!$link || empty($link['planfix_object_id'])) {
+                return;
+            }
+        }
+
+        $planfix_object_id = (string) $link['planfix_object_id'];
+        $planfix_object_type = isset($link['planfix_object_type']) && $link['planfix_object_type'] !== ''
+            ? (string) $link['planfix_object_type']
+            : 'task';
+
+        $payloads = [];
+        $status_payload = [
+            'order_id'            => $order_id,
+            'company_id'          => $company_id,
+            'status_to'           => (string) $status_to,
+            'status_from'         => (string) $status_from,
+            'planfix_object_id'   => $planfix_object_id,
+            'planfix_object_type' => $planfix_object_type,
+        ];
+
+        if (isset($order_info['total'])) {
+            $status_payload['total'] = (float) $order_info['total'];
+        }
+
+        $payloads['update_sale_status'] = $status_payload;
+        $this->client->updateSaleStatus($status_payload);
+
+        if ($this->settings->shouldSyncComments()) {
+            $comment = '';
+
+            if (!empty($order_info['details'])) {
+                $comment = (string) $order_info['details'];
+            } elseif (!empty($order_info['notes'])) {
+                $comment = (string) $order_info['notes'];
+            }
+
+            if ($comment !== '') {
+                $comment_payload = [
+                    'order_id'            => $order_id,
+                    'company_id'          => $company_id,
+                    'planfix_object_id'   => $planfix_object_id,
+                    'planfix_object_type' => $planfix_object_type,
+                    'comment'             => $comment,
+                ];
+
+                $payloads['append_sale_comment'] = $comment_payload;
+                $this->client->appendSaleComment($comment_payload);
+            }
+        }
+
+        if ($this->settings->shouldSyncPayments()) {
+            $amount = null;
+
+            if (isset($order_info['total_paid'])) {
+                $amount = (float) $order_info['total_paid'];
+            } elseif (isset($order_info['total'])) {
+                $amount = (float) $order_info['total'];
+            }
+
+            if ($amount !== null) {
+                $payment_payload = [
+                    'order_id'            => $order_id,
+                    'company_id'          => $company_id,
+                    'planfix_object_id'   => $planfix_object_id,
+                    'planfix_object_type' => $planfix_object_type,
+                    'amount'              => $amount,
+                ];
+
+                if (!empty($order_info['secondary_currency'])) {
+                    $payment_payload['currency'] = (string) $order_info['secondary_currency'];
+                } elseif (!empty($order_info['primary_currency'])) {
+                    $payment_payload['currency'] = (string) $order_info['primary_currency'];
+                } elseif (!empty($order_info['currency'])) {
+                    $payment_payload['currency'] = (string) $order_info['currency'];
+                }
+
+                $payloads['register_sale_payment'] = $payment_payload;
+                $this->client->registerSalePayment($payment_payload);
+            }
+        }
+
+        $summary_extra = [
+            'last_outgoing_status' => [
+                'status_to'   => (string) $status_to,
+                'status_from' => (string) $status_from,
+                'pushed_at'   => TIME,
+            ],
+        ];
+
+        $this->updateLinkExtra(
+            $link,
+            $summary_extra,
+            [
+                'last_push_at'     => TIME,
+                'last_payload_out' => json_encode($payloads, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ]
+        );
+    }
+
+    public function processIncomingOrderStatus(array $link, string $target_status): array
+    {
+        if ($target_status === '' || ($link['entity_type'] ?? '') !== 'order') {
+            return [
+                'success' => true,
+                'message' => 'Link metadata updated',
+            ];
+        }
+
+        $order_id = (int) ($link['entity_id'] ?? 0);
+        if (!$order_id) {
+            return [
+                'success' => true,
+                'message' => 'Link metadata updated',
+            ];
+        }
+
+        $current_status = call_user_func($this->orderStatusFetcher, $order_id);
+
+        if ($current_status === $target_status) {
+            return [
+                'success' => true,
+                'message' => 'Order status already up to date',
+            ];
+        }
+
+        $this->recordStatusSkip($order_id);
+        $updated = call_user_func($this->orderStatusUpdater, $order_id, $target_status, (string) $current_status);
+
+        if ($updated) {
+            return [
+                'success' => true,
+                'message' => 'Order status updated',
+            ];
+        }
+
+        return [
+            'success' => false,
+            'message' => 'Failed to update order status',
+        ];
+    }
+}

--- a/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Planfix/WebhookHandler.php
+++ b/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Planfix/WebhookHandler.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Planfix;
+
+class WebhookHandler
+{
+    /** @var IntegrationSettings */
+    private $settings;
+
+    /** @var LinkRepository */
+    private $linkRepository;
+
+    /** @var StatusMapRepository */
+    private $statusMapRepository;
+
+    /** @var PlanfixService */
+    private $planfixService;
+
+    public function __construct(
+        IntegrationSettings $settings,
+        LinkRepository $linkRepository,
+        StatusMapRepository $statusMapRepository,
+        PlanfixService $planfixService
+    ) {
+        $this->settings = $settings;
+        $this->linkRepository = $linkRepository;
+        $this->statusMapRepository = $statusMapRepository;
+        $this->planfixService = $planfixService;
+    }
+
+    public function handleStatusWebhook(array $server, string $rawBody, array $fallbackPayload = []): WebhookResponse
+    {
+        $method = strtoupper((string) ($server['REQUEST_METHOD'] ?? ''));
+        if ($method !== 'POST') {
+            return new WebhookResponse(405, [
+                'success' => false,
+                'message' => 'Method Not Allowed',
+            ]);
+        }
+
+        if (!$this->isIpAllowlisted((string) ($server['REMOTE_ADDR'] ?? ''))) {
+            return new WebhookResponse(403, [
+                'success' => false,
+                'message' => 'IP is not allowed',
+            ]);
+        }
+
+        if (!$this->validateBasicAuth($server)) {
+            return new WebhookResponse(401, [
+                'success' => false,
+                'message' => 'Unauthorized',
+            ], ['WWW-Authenticate' => 'Basic realm="Planfix webhook"']);
+        }
+
+        $payload = $this->parsePayload($rawBody, $fallbackPayload);
+        $planfix_task_id = $this->extractPlanfixTaskId($payload);
+
+        if ($planfix_task_id === '') {
+            return new WebhookResponse(400, [
+                'success' => false,
+                'message' => 'planfix_task_id is required',
+            ]);
+        }
+
+        $link = $this->linkRepository->findByPlanfix('task', $planfix_task_id);
+        if (!$link) {
+            return new WebhookResponse(404, [
+                'success' => false,
+                'message' => 'Link not found',
+            ]);
+        }
+
+        $status_id = isset($payload['status_id']) ? (string) $payload['status_id'] : '';
+        $extra_updates = [
+            'planfix_meta' => [
+                'status_id'   => $status_id,
+                'updated_at'  => TIME,
+            ],
+            'last_incoming_status' => [
+                'status_id'   => $status_id,
+                'received_at' => TIME,
+            ],
+            'last_planfix_payload_in' => [
+                'received_at' => TIME,
+                'payload'     => $payload,
+            ],
+        ];
+
+        $target_status = null;
+        if ($status_id !== '') {
+            $status_map = $this->statusMapRepository->findLocalStatus(
+                (int) $link['company_id'],
+                (string) $link['entity_type'],
+                $status_id
+            );
+
+            if ($status_map && !empty($status_map['entity_status'])) {
+                $target_status = (string) $status_map['entity_status'];
+                $extra_updates['planfix_meta']['mapped_status'] = $target_status;
+            }
+        }
+
+        $message_details = [];
+
+        if ($status_id !== '') {
+            $planfix_status_details = [];
+            $planfix_status_details[] = 'id ' . $status_id;
+
+            $planfix_status_message = 'Planfix status ' . implode(', ', $planfix_status_details);
+
+            if ($target_status !== null && $status_id !== '') {
+                $planfix_status_message .= ' -> entity status ' . $target_status;
+            }
+
+            $message_details[] = $planfix_status_message;
+        }
+
+        if ($target_status !== null && $status_id === '') {
+            $message_details[] = 'Mapped entity status ' . $target_status;
+        }
+
+        $message_details[] = 'status_id: ' . $status_id;
+        $message_details[] = 'target_status: ' . (string) $target_status;
+
+        $result = $this->planfixService->processIncomingOrderStatus($link, (string) ($target_status ?? ''));
+        $message = $result['message'] ?? 'Link metadata updated';
+        $success = (bool) ($result['success'] ?? true);
+
+        if ($message_details) {
+            $message .= ': ' . implode('; ', $message_details);
+        }
+
+        $this->planfixService->updateLinkExtra($link, $extra_updates);
+
+        return new WebhookResponse($success ? 200 : 500, [
+            'success' => $success,
+            'message' => $message,
+        ]);
+    }
+
+    private function isIpAllowlisted(string $remote_ip): bool
+    {
+        $allowlist = $this->settings->getWebhookAllowlistIps();
+        if (!$allowlist) {
+            return true;
+        }
+
+        $remote_ip = trim($remote_ip);
+        if ($remote_ip === '') {
+            return false;
+        }
+
+        $normalized = array_map(static function ($ip) {
+            return trim((string) $ip);
+        }, $allowlist);
+
+        return in_array($remote_ip, $normalized, true);
+    }
+
+    private function validateBasicAuth(array $server): bool
+    {
+        [$expected_login, $expected_password] = $this->settings->getWebhookBasicAuthCredentials();
+
+        $expected_login = (string) $expected_login;
+        $expected_password = (string) $expected_password;
+
+        if ($expected_login === '' && $expected_password === '') {
+            return true;
+        }
+
+        $credentials = $this->extractCredentials($server);
+        if ($credentials === null) {
+            return false;
+        }
+
+        [$login, $password] = $credentials;
+
+        if (!function_exists('hash_equals')) {
+            return $expected_login === $login && $expected_password === $password;
+        }
+
+        return hash_equals($expected_login, $login) && hash_equals($expected_password, $password);
+    }
+
+    private function parsePayload(string $rawBody, array $fallbackPayload): array
+    {
+        if ($rawBody !== '') {
+            $decoded = json_decode($rawBody, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return is_array($fallbackPayload) ? $fallbackPayload : [];
+    }
+
+    private function extractPlanfixTaskId(array $payload): string
+    {
+        foreach (['planfix_task_id', 'task_id', 'id'] as $key) {
+            if (!empty($payload[$key])) {
+                return (string) $payload[$key];
+            }
+        }
+
+        return '';
+    }
+
+    private function extractCredentials(array $server): ?array
+    {
+        if (isset($server['PHP_AUTH_USER'])) {
+            $login = (string) $server['PHP_AUTH_USER'];
+            $password = isset($server['PHP_AUTH_PW']) ? (string) $server['PHP_AUTH_PW'] : '';
+
+            return [$login, $password];
+        }
+
+        $headers = [];
+
+        foreach (['HTTP_AUTHORIZATION', 'REDIRECT_HTTP_AUTHORIZATION'] as $header) {
+            if (!empty($server[$header])) {
+                $headers[] = (string) $server[$header];
+            }
+        }
+
+        foreach ($headers as $header) {
+            if (stripos($header, 'Basic ') === 0) {
+                $decoded = base64_decode(substr($header, 6), true);
+                if ($decoded !== false) {
+                    $parts = explode(':', $decoded, 2);
+                    if (count($parts) === 2) {
+                        return [(string) $parts[0], (string) $parts[1]];
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}
+
+class WebhookResponse
+{
+    /** @var int */
+    private $statusCode;
+
+    /** @var array */
+    private $payload;
+
+    /** @var array */
+    private $headers;
+
+    public function __construct(int $statusCode, array $payload, array $headers = [])
+    {
+        $this->statusCode = $statusCode;
+        $this->payload = $payload;
+        $this->headers = $headers;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+}

--- a/app/addons/mwl_xlsx/composer.json
+++ b/app/addons/mwl_xlsx/composer.json
@@ -7,5 +7,13 @@
         "psr-4": {
             "Tygh\\": "Tygh/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tygh\\Addons\\MwlXlsx\\Tests\\": "tests/"
+        }
     }
 }

--- a/app/addons/mwl_xlsx/composer.lock
+++ b/app/addons/mwl_xlsx/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "046deed3a98e8b9974cd9dba82c4188d",
+    "content-hash": "d520463ec195ee570c28db1300587d52",
     "packages": [
         {
             "name": "composer/pcre",
@@ -1751,7 +1751,1677 @@
             "time": "2024-09-25T14:21:43+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+            },
+            "time": "2025-08-13T20:13:15+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.58",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-28T12:04:46+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-07T05:25:07+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:36:25+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},

--- a/app/addons/mwl_xlsx/controllers/backend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/backend/mwl_xlsx.php
@@ -46,7 +46,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $mode === 'planfix_create_task') {
         return [CONTROLLER_STATUS_OK, $return_url];
     }
 
-    $result = fn_mwl_planfix_create_task_for_order($order_id, $order_info);
+    $planfix_service = fn_mwl_planfix_service();
+    $result = $planfix_service->createTaskForOrder($order_id, $order_info);
 
     if (defined('AJAX_REQUEST')) {
         Tygh::$app['ajax']->assign('success', (bool) ($result['success'] ?? false));
@@ -94,7 +95,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $mode === 'planfix_bind_task') {
 
     $company_id = (int) db_get_field('SELECT company_id FROM ?:orders WHERE order_id = ?i', $order_id);
 
-    $result = fn_mwl_planfix_bind_task_to_order($order_id, $company_id, $planfix_task_id, $planfix_object_type);
+    $planfix_service = fn_mwl_planfix_service();
+    $result = $planfix_service->bindTaskToOrder($order_id, $company_id, $planfix_task_id, $planfix_object_type);
 
     if (!empty($result['success'])) {
         fn_set_notification('N', __('notice'), $result['message']);

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -12,7 +12,16 @@ use Google\Service\Sheets;
 use Google\Service\Sheets\Spreadsheet;
 
 if ($mode === 'planfix_changed_status') {
-    fn_mwl_planfix_handle_planfix_status_webhook();
+    $handler = fn_mwl_planfix_webhook_handler();
+    $raw_body = file_get_contents('php://input');
+    $response = $handler->handleStatusWebhook($_SERVER, is_string($raw_body) ? $raw_body : '', $_REQUEST);
+
+    foreach ($response->getHeaders() as $header => $value) {
+        header($header . ': ' . $value);
+    }
+
+    fn_mwl_planfix_output_json($response->getStatusCode(), $response->getPayload());
+
     return [CONTROLLER_STATUS_NO_CONTENT];
 }
 

--- a/app/addons/mwl_xlsx/phpunit.xml.dist
+++ b/app/addons/mwl_xlsx/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="MwlXlsx">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/app/addons/mwl_xlsx/tests/Planfix/PlanfixServiceTest.php
+++ b/app/addons/mwl_xlsx/tests/Planfix/PlanfixServiceTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Tests\Planfix;
+
+use PHPUnit\Framework\TestCase;
+use Tygh\Addons\MwlXlsx\Planfix\IntegrationSettings;
+use Tygh\Addons\MwlXlsx\Planfix\LinkRepository;
+use Tygh\Addons\MwlXlsx\Planfix\McpClient;
+use Tygh\Addons\MwlXlsx\Planfix\PlanfixService;
+use Tygh\Addons\MwlXlsx\Telegram\TelegramService;
+use Tygh\Registry;
+
+class PlanfixServiceTest extends TestCase
+{
+    public function testCreateTaskForOrderSuccess(): void
+    {
+        Registry::set('addons.mwl_xlsx.planfix_origin', 'https://planfix.test');
+
+        $settings = IntegrationSettings::fromArray([
+            'mcp_endpoint'       => 'https://mcp.example.com',
+            'mcp_auth_token'     => 'token',
+            'direction_default'  => 'default',
+        ]);
+
+        $linkRepository = $this->createMock(LinkRepository::class);
+        $client = $this->createMock(McpClient::class);
+        $telegram = $this->createMock(TelegramService::class);
+
+        $order_id = 100;
+        $company_id = 7;
+        $order_info = [
+            'order_id'  => $order_id,
+            'company_id'=> $company_id,
+            'email'     => 'customer@example.com',
+            'status'    => 'P',
+            'total'     => 150.50,
+            'currency'  => 'USD',
+            'products'  => [
+                ['product' => 'Product A', 'amount' => 2, 'subtotal' => 99.99],
+            ],
+            'user_id'   => 5,
+            'firstname' => 'John',
+            'lastname'  => 'Doe',
+            'planfix_meta' => ['source' => 'test'],
+        ];
+
+        $user_data = [
+            'company'   => 'Acme',
+            'firstname' => 'John',
+            'lastname'  => 'Doe',
+        ];
+
+        $linkRepository
+            ->expects($this->once())
+            ->method('upsert')
+            ->with(
+                $company_id,
+                'order',
+                $order_id,
+                'task',
+                'PF-1',
+                $this->callback(static function ($extra) {
+                    return isset($extra['planfix_meta']['direction']) && $extra['created_via'] === 'planfix_create_sell_task';
+                })
+            );
+
+        $linkInitial = [
+            'link_id' => 42,
+            'planfix_object_id' => 'PF-1',
+            'planfix_object_type' => 'task',
+            'company_id' => $company_id,
+            'entity_id' => $order_id,
+            'extra' => null,
+        ];
+
+        $linkFinal = [
+            'link_id' => 42,
+            'planfix_object_id' => 'PF-1',
+            'planfix_object_type' => 'task',
+            'company_id' => $company_id,
+            'entity_id' => $order_id,
+        ];
+
+        $findCalls = 0;
+        $testCase = $this;
+        $linkRepository
+            ->expects($this->exactly(2))
+            ->method('findByEntity')
+            ->willReturnCallback(function ($company, $type, $entity) use (&$findCalls, $company_id, $order_id, $linkInitial, $linkFinal, $testCase) {
+                $testCase->assertSame($company_id, $company);
+                $testCase->assertSame('order', $type);
+                $testCase->assertSame($order_id, $entity);
+
+                $findCalls++;
+
+                return $findCalls === 1 ? $linkInitial : $linkFinal;
+            });
+
+        $linkRepository
+            ->expects($this->once())
+            ->method('update')
+            ->with(
+                42,
+                $this->callback(function (array $data) {
+                    $this->assertArrayHasKey('last_payload_out', $data);
+                    $payloads = json_decode($data['last_payload_out'], true);
+                    $this->assertArrayHasKey('planfix_create_sell_task', $payloads);
+                    return isset($data['extra']) && is_array($data['extra']);
+                })
+            );
+
+        $client
+            ->expects($this->once())
+            ->method('createTask')
+            ->with($this->callback(static function (array $payload) {
+                return $payload['direction'] === 'default' && $payload['email'] === 'customer@example.com';
+            }))
+            ->willReturn([
+                'success' => true,
+                'data' => [
+                    'taskId' => 'PF-1',
+                    'planfix_object_type' => 'task',
+                    'url' => 'https://planfix.example.com/task/PF-1',
+                    'status_id' => 'STATUS',
+                ],
+            ]);
+
+        $telegram
+            ->expects($this->once())
+            ->method('resolveUserTelegram')
+            ->with(5, $user_data)
+            ->willReturn('@john');
+
+        $service = new PlanfixService(
+            $linkRepository,
+            $client,
+            $settings,
+            $telegram,
+            null,
+            static function (int $user_id) use ($user_data) {
+                return $user_data;
+            },
+            static function (int $order_id): string {
+                return 'https://example.com/orders/' . $order_id;
+            }
+        );
+
+        $result = $service->createTaskForOrder($order_id, $order_info);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('mwl_xlsx.planfix_task_created', $result['message']);
+        $this->assertSame('https://planfix.test/task/PF-1', $result['link']['planfix_url']);
+        $this->assertSame('PF-1', $result['link']['planfix_object_id']);
+    }
+
+    public function testSyncOrderStatusSendsPayloads(): void
+    {
+        $settings = IntegrationSettings::fromArray([
+            'mcp_endpoint'      => 'https://mcp.example.com',
+            'mcp_auth_token'    => 'token',
+            'direction_default' => 'default',
+            'sync_comments'     => 'Y',
+            'sync_payments'     => 'Y',
+        ]);
+
+        $link = [
+            'link_id' => 10,
+            'planfix_object_id' => 'PF-2',
+            'planfix_object_type' => 'task',
+            'company_id' => 3,
+            'entity_id' => 77,
+            'extra' => null,
+        ];
+
+        $linkRepository = $this->createMock(LinkRepository::class);
+        $linkRepository
+            ->expects($this->once())
+            ->method('findByEntity')
+            ->with(3, 'order', 77)
+            ->willReturn($link);
+
+        $linkRepository
+            ->expects($this->once())
+            ->method('update')
+            ->with(
+                10,
+                $this->callback(function (array $data) {
+                    $payloads = json_decode($data['last_payload_out'], true);
+                    $this->assertArrayHasKey('update_sale_status', $payloads);
+                    $this->assertArrayHasKey('append_sale_comment', $payloads);
+                    $this->assertArrayHasKey('register_sale_payment', $payloads);
+                    return true;
+                })
+            );
+
+        $client = $this->createMock(McpClient::class);
+        $client->expects($this->once())->method('updateSaleStatus');
+        $client->expects($this->once())->method('appendSaleComment');
+        $client->expects($this->once())->method('registerSalePayment');
+
+        $telegram = $this->createMock(TelegramService::class);
+
+        $service = new PlanfixService(
+            $linkRepository,
+            $client,
+            $settings,
+            $telegram
+        );
+
+        $order_info = [
+            'company_id' => 3,
+            'details' => 'Test comment',
+            'total_paid' => 200.0,
+            'secondary_currency' => 'USD',
+        ];
+
+        $service->syncOrderStatus(77, 'C', 'O', $order_info);
+    }
+
+    public function testRecordAndConsumeStatusSkip(): void
+    {
+        $settings = IntegrationSettings::fromArray([]);
+        $linkRepository = $this->createMock(LinkRepository::class);
+        $client = $this->createMock(McpClient::class);
+        $telegram = $this->createMock(TelegramService::class);
+
+        $service = new PlanfixService($linkRepository, $client, $settings, $telegram);
+
+        $order_id = 501;
+
+        $service->recordStatusSkip($order_id);
+        $this->assertTrue($service->consumeStatusSkip($order_id));
+        $this->assertFalse($service->consumeStatusSkip($order_id));
+    }
+}

--- a/app/addons/mwl_xlsx/tests/Planfix/WebhookHandlerTest.php
+++ b/app/addons/mwl_xlsx/tests/Planfix/WebhookHandlerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Tests\Planfix;
+
+use PHPUnit\Framework\TestCase;
+use Tygh\Addons\MwlXlsx\Planfix\IntegrationSettings;
+use Tygh\Addons\MwlXlsx\Planfix\LinkRepository;
+use Tygh\Addons\MwlXlsx\Planfix\PlanfixService;
+use Tygh\Addons\MwlXlsx\Planfix\StatusMapRepository;
+use Tygh\Addons\MwlXlsx\Planfix\WebhookHandler;
+use Tygh\Addons\MwlXlsx\Planfix\WebhookResponse;
+
+class WebhookHandlerTest extends TestCase
+{
+    public function testRejectsNonAllowlistedIp(): void
+    {
+        $settings = IntegrationSettings::fromArray([
+            'webhook_allowlist_ips' => ['1.1.1.1'],
+        ]);
+
+        $linkRepository = $this->createMock(LinkRepository::class);
+        $statusMapRepository = $this->createMock(StatusMapRepository::class);
+        $planfixService = $this->createMock(PlanfixService::class);
+        $planfixService->expects($this->never())->method('updateLinkExtra');
+
+        $handler = new WebhookHandler($settings, $linkRepository, $statusMapRepository, $planfixService);
+
+        $response = $handler->handleStatusWebhook(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'REMOTE_ADDR' => '2.2.2.2',
+            ],
+            '{}',
+            []
+        );
+
+        $this->assertInstanceOf(WebhookResponse::class, $response);
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertFalse($response->getPayload()['success']);
+    }
+
+    public function testRequiresBasicAuthWhenCredentialsProvided(): void
+    {
+        $settings = IntegrationSettings::fromArray([
+            'webhook_allowlist_ips' => ['1.1.1.1'],
+            'webhook_basic_login' => 'user',
+            'webhook_basic_password' => 'pass',
+        ]);
+
+        $handler = new WebhookHandler(
+            $settings,
+            $this->createMock(LinkRepository::class),
+            $this->createMock(StatusMapRepository::class),
+            $this->createMock(PlanfixService::class)
+        );
+
+        $response = $handler->handleStatusWebhook(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'REMOTE_ADDR' => '1.1.1.1',
+            ],
+            '{}',
+            []
+        );
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertArrayHasKey('WWW-Authenticate', $response->getHeaders());
+    }
+
+    public function testUpdatesMetadataAndProcessesStatus(): void
+    {
+        $settings = IntegrationSettings::fromArray([
+            'webhook_allowlist_ips' => ['10.0.0.1'],
+            'webhook_basic_login' => 'user',
+            'webhook_basic_password' => 'pass',
+        ]);
+
+        $link = [
+            'link_id' => 9,
+            'entity_type' => 'order',
+            'entity_id' => 55,
+            'company_id' => 3,
+        ];
+
+        $linkRepository = $this->createMock(LinkRepository::class);
+        $linkRepository
+            ->expects($this->once())
+            ->method('findByPlanfix')
+            ->with('task', 'PF-5')
+            ->willReturn($link);
+
+        $statusMapRepository = $this->createMock(StatusMapRepository::class);
+        $statusMapRepository
+            ->expects($this->once())
+            ->method('findLocalStatus')
+            ->with(3, 'order', 'S1')
+            ->willReturn(['entity_status' => 'C']);
+
+        $planfixService = $this->createMock(PlanfixService::class);
+        $planfixService
+            ->expects($this->once())
+            ->method('processIncomingOrderStatus')
+            ->with($link, 'C')
+            ->willReturn([
+                'success' => true,
+                'message' => 'Order status updated',
+            ]);
+
+        $planfixService
+            ->expects($this->once())
+            ->method('updateLinkExtra')
+            ->with(
+                $link,
+                $this->callback(function (array $updates) {
+                    $this->assertSame('S1', $updates['planfix_meta']['status_id']);
+                    $this->assertSame('C', $updates['planfix_meta']['mapped_status']);
+                    $this->assertSame('S1', $updates['last_incoming_status']['status_id']);
+                    return true;
+                })
+            );
+
+        $handler = new WebhookHandler($settings, $linkRepository, $statusMapRepository, $planfixService);
+
+        $response = $handler->handleStatusWebhook(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'REMOTE_ADDR' => '10.0.0.1',
+                'PHP_AUTH_USER' => 'user',
+                'PHP_AUTH_PW' => 'pass',
+            ],
+            json_encode(['planfix_task_id' => 'PF-5', 'status_id' => 'S1']),
+            []
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertTrue($response->getPayload()['success']);
+        $this->assertStringContainsString('Order status updated', $response->getPayload()['message']);
+        $this->assertStringContainsString('status_id: S1', $response->getPayload()['message']);
+    }
+}

--- a/app/addons/mwl_xlsx/tests/Support/RegistryStub.php
+++ b/app/addons/mwl_xlsx/tests/Support/RegistryStub.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Tests\Support;
+
+class RegistryStub
+{
+    private static $data = [];
+
+    public static function get($key)
+    {
+        return self::$data[$key] ?? '';
+    }
+
+    public static function set($key, $value): void
+    {
+        self::$data[$key] = $value;
+    }
+}

--- a/app/addons/mwl_xlsx/tests/Support/TyghStub.php
+++ b/app/addons/mwl_xlsx/tests/Support/TyghStub.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Tests\Support;
+
+class TyghStub
+{
+    public static $app;
+}

--- a/app/addons/mwl_xlsx/tests/bootstrap.php
+++ b/app/addons/mwl_xlsx/tests/bootstrap.php
@@ -1,0 +1,118 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (!class_exists('Tygh\\Registry')) {
+    class_alias(Tygh\Addons\MwlXlsx\Tests\Support\RegistryStub::class, 'Tygh\\Registry');
+}
+
+if (!class_exists('Tygh\\Tygh')) {
+    class_alias(Tygh\Addons\MwlXlsx\Tests\Support\TyghStub::class, 'Tygh\\Tygh');
+}
+
+if (!isset(\Tygh\Tygh::$app)) {
+    \Tygh\Tygh::$app = new \ArrayObject();
+}
+
+if (!defined('TIME')) {
+    define('TIME', 1700000000);
+}
+
+if (!defined('CART_LANGUAGE')) {
+    define('CART_LANGUAGE', 'en');
+}
+
+if (!function_exists('__')) {
+    function __($key, array $params = [], $lang_code = null)
+    {
+        foreach ($params as $placeholder => $value) {
+            $key = str_replace($placeholder, (string) $value, $key);
+        }
+
+        return $key;
+    }
+}
+
+if (!function_exists('fn_url')) {
+    function fn_url($url, $area = 'A', $protocol = 'current', $lang_code = CART_LANGUAGE, $get_relative = true)
+    {
+        return 'https://example.com/' . ltrim($url, '/');
+    }
+}
+
+if (!function_exists('fn_get_order_info')) {
+    function fn_get_order_info($order_id)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('fn_get_user_info')) {
+    function fn_get_user_info($user_id)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('fn_change_order_status')) {
+    function fn_change_order_status($order_id, $status_to, $status_from)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('db_get_field')) {
+    function db_get_field($query, ...$params)
+    {
+        return '';
+    }
+}
+
+if (!function_exists('db_query')) {
+    function db_query($query, ...$params)
+    {
+        return 0;
+    }
+}
+
+if (!function_exists('db_get_row')) {
+    function db_get_row($query, ...$params)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('db_get_array')) {
+    function db_get_array($query, ...$params)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('db_get_hash_array')) {
+    function db_get_hash_array($query, ...$params)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('db_get_fields')) {
+    function db_get_fields($query, ...$params)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('fn_format_order_id')) {
+    function fn_format_order_id($order_id)
+    {
+        return (string) $order_id;
+    }
+}
+
+if (!function_exists('fn_mwl_planfix_format_order_id')) {
+    function fn_mwl_planfix_format_order_id($order_id)
+    {
+        return (string) $order_id;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated PlanfixService for task lifecycle orchestration and status sync
- add a WebhookHandler to validate Planfix callbacks and persist metadata updates
- update controllers/hooks to use the new services and add PHPUnit-based tests

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e259f5eeb4832cb951eb767e11d4e5