### PR TITLE
Refactor Media List access checks into AccessService

### DIFF
--- a/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Security/AccessService.php
+++ b/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Security/AccessService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Security;
+
+use Tygh\Registry;
+
+class AccessService
+{
+    public function checkUsergroupAccess(array $auth, string $setting_key): bool
+    {
+        if (($auth['user_type'] ?? '') === 'A') {
+            return true;
+        }
+
+        $allowed = Registry::get("addons.mwl_xlsx.$setting_key");
+
+        if ($allowed === '' || $allowed === null) {
+            return true;
+        }
+
+        if (is_array($allowed)) {
+            if (!$allowed) {
+                return true;
+            }
+
+            $allowed_usergroups = array_map('intval', $allowed);
+        } else {
+            $allowed_string = (string) $allowed;
+
+            if ($allowed_string === '') {
+                return true;
+            }
+
+            $allowed_usergroups = array_map('intval', explode(',', $allowed_string));
+
+            if (!$allowed_usergroups) {
+                return true;
+            }
+        }
+
+        $usergroups = array_map('intval', $auth['usergroup_ids'] ?? []);
+
+        return (bool) array_intersect($allowed_usergroups, $usergroups);
+    }
+
+    public function canAccessLists(array $auth): bool
+    {
+        return $this->checkUsergroupAccess($auth, 'allowed_usergroups');
+    }
+
+    public function canViewPrice(array $auth): bool
+    {
+        if (($auth['user_type'] ?? '') === 'A') {
+            return true;
+        }
+
+        if (Registry::get('addons.mwl_xlsx.hide_price_for_guests') === 'Y' && empty($auth['user_id'])) {
+            return false;
+        }
+
+        return $this->checkUsergroupAccess($auth, 'authorized_usergroups');
+    }
+}

--- a/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
+++ b/app/addons/mwl_xlsx/controllers/frontend/mwl_xlsx.php
@@ -25,7 +25,7 @@ if ($mode === 'planfix_changed_status') {
     return [CONTROLLER_STATUS_NO_CONTENT];
 }
 
-if (!fn_mwl_xlsx_user_can_access_lists($auth)) {
+if (!fn_mwl_xlsx_access_service()->canAccessLists($auth)) {
     return [CONTROLLER_STATUS_DENIED];
 }
 

--- a/app/addons/mwl_xlsx/init.php
+++ b/app/addons/mwl_xlsx/init.php
@@ -57,7 +57,7 @@ function fn_mwl_xlsx_get_product_filter_fields(&$filters)
 {
     // return if user can access prices
     $auth = Tygh::$app['session']['auth'] ?? [];
-    if (fn_mwl_xlsx_can_view_price($auth)) {
+    if (fn_mwl_xlsx_access_service()->canViewPrice($auth)) {
         return;
     }
 

--- a/app/addons/mwl_xlsx/tests/Security/AccessServiceTest.php
+++ b/app/addons/mwl_xlsx/tests/Security/AccessServiceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Tygh\Addons\MwlXlsx\Security\AccessService;
+use Tygh\Registry;
+
+class AccessServiceTest extends TestCase
+{
+    private AccessService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new AccessService();
+
+        Registry::set('addons.mwl_xlsx.allowed_usergroups', '');
+        Registry::set('addons.mwl_xlsx.authorized_usergroups', '');
+        Registry::set('addons.mwl_xlsx.hide_price_for_guests', 'N');
+    }
+
+    /**
+     * @dataProvider usergroupAccessProvider
+     */
+    public function testCheckUsergroupAccess(array $auth, $setting_value, bool $expected): void
+    {
+        Registry::set('addons.mwl_xlsx.test_setting', $setting_value);
+
+        $actual = $this->service->checkUsergroupAccess($auth, 'test_setting');
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function usergroupAccessProvider(): array
+    {
+        return [
+            'administrators always allowed' => [
+                ['user_type' => 'A'],
+                '1,2,3',
+                true,
+            ],
+            'empty setting allows everyone' => [
+                ['user_type' => 'C', 'usergroup_ids' => [5]],
+                '',
+                true,
+            ],
+            'matching usergroup passes' => [
+                ['user_type' => 'C', 'usergroup_ids' => [3, 5]],
+                '2,5',
+                true,
+            ],
+            'no intersection fails' => [
+                ['user_type' => 'C', 'usergroup_ids' => [7]],
+                '2,5',
+                false,
+            ],
+            'array setting supported' => [
+                ['user_type' => 'C', 'usergroup_ids' => [10]],
+                [8, 10, 12],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider canAccessListsProvider
+     */
+    public function testCanAccessLists(array $auth, $setting_value, bool $expected): void
+    {
+        Registry::set('addons.mwl_xlsx.allowed_usergroups', $setting_value);
+
+        $this->assertSame($expected, $this->service->canAccessLists($auth));
+    }
+
+    public function canAccessListsProvider(): array
+    {
+        return [
+            'admin can access lists' => [
+                ['user_type' => 'A'],
+                '2',
+                true,
+            ],
+            'allowed group' => [
+                ['user_type' => 'C', 'usergroup_ids' => [2]],
+                '2,4',
+                true,
+            ],
+            'not allowed group' => [
+                ['user_type' => 'C', 'usergroup_ids' => [3]],
+                '2,4',
+                false,
+            ],
+            'empty setting allows all' => [
+                ['user_type' => 'C', 'usergroup_ids' => [3]],
+                '',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider canViewPriceProvider
+     */
+    public function testCanViewPrice(array $auth, string $hide_for_guests, $authorized_usergroups, bool $expected): void
+    {
+        Registry::set('addons.mwl_xlsx.hide_price_for_guests', $hide_for_guests);
+        Registry::set('addons.mwl_xlsx.authorized_usergroups', $authorized_usergroups);
+
+        $this->assertSame($expected, $this->service->canViewPrice($auth));
+    }
+
+    public function canViewPriceProvider(): array
+    {
+        return [
+            'guest blocked when setting enabled' => [
+                ['user_type' => 'C'],
+                'Y',
+                '1,2,3',
+                false,
+            ],
+            'admin bypasses restrictions' => [
+                ['user_type' => 'A'],
+                'Y',
+                '1,2,3',
+                true,
+            ],
+            'logged-in customer allowed when in group' => [
+                ['user_type' => 'C', 'user_id' => 50, 'usergroup_ids' => [7, 9]],
+                'Y',
+                '5,9',
+                true,
+            ],
+            'logged-in customer denied when not in group' => [
+                ['user_type' => 'C', 'user_id' => 51, 'usergroup_ids' => [3]],
+                'N',
+                '5,9',
+                false,
+            ],
+            'guest allowed when flag disabled and no restriction' => [
+                ['user_type' => 'C'],
+                'N',
+                '',
+                true,
+            ],
+            'guest allowed with matching group even when flagged off' => [
+                ['user_type' => 'C', 'usergroup_ids' => [4]],
+                'N',
+                '4,8',
+                true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add Tygh\\Addons\\MwlXlsx\\Security\\AccessService to centralize Media List permission checks and expose it via fn_mwl_xlsx_access_service
- update existing PHP helpers, Smarty integration, and controller logic to rely on the new access service
- cover access combinations for lists and price visibility with PHPUnit tests

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68e260dc0910832c865c2f7bade39b67