### PR TITLE
Refactor media list logic into services and add tests

### DIFF
--- a/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/MediaList/ListRepository.php
+++ b/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/MediaList/ListRepository.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\MediaList;
+
+use InvalidArgumentException;
+use Tygh\Database\Connection;
+use Tygh\Registry;
+use Tygh\Tygh;
+
+class ListRepository
+{
+    /** @var Connection */
+    private $db;
+
+    /** @var bool */
+    private $userSettingsTableEnsured = false;
+
+    public function __construct(?Connection $db = null)
+    {
+        if ($db === null) {
+            $container = Tygh::$app ?? null;
+            if ($container instanceof \ArrayAccess && $container->offsetExists('db')) {
+                $db = $container['db'];
+            }
+        }
+
+        if (!$db instanceof Connection) {
+            throw new InvalidArgumentException('Database connection is required');
+        }
+
+        $this->db = $db;
+    }
+
+    public function findByUserId(int $list_id, int $user_id): ?array
+    {
+        return $this->db->getRow(
+            'SELECT * FROM ?:mwl_xlsx_lists WHERE list_id = ?i AND user_id = ?i',
+            $list_id,
+            $user_id
+        ) ?: null;
+    }
+
+    public function findBySessionId(int $list_id, string $session_id): ?array
+    {
+        return $this->db->getRow(
+            'SELECT * FROM ?:mwl_xlsx_lists WHERE list_id = ?i AND session_id = ?s',
+            $list_id,
+            $session_id
+        ) ?: null;
+    }
+
+    public function getListsByUserId(int $user_id): array
+    {
+        return $this->getLists(['user_id' => $user_id]);
+    }
+
+    public function getListsBySessionId(string $session_id): array
+    {
+        return $this->getLists(['session_id' => $session_id]);
+    }
+
+    private function getLists(array $condition): array
+    {
+        return $this->db->getArray(
+            'SELECT l.*, COUNT(lp.product_id) AS products_count'
+            . ' FROM ?:mwl_xlsx_lists AS l'
+            . ' LEFT JOIN ?:mwl_xlsx_list_products AS lp ON lp.list_id = l.list_id'
+            . ' WHERE ?w GROUP BY l.list_id ORDER BY l.created_at ASC',
+            $condition
+        );
+    }
+
+    public function countListsByUserId(int $user_id): int
+    {
+        return (int) $this->db->getField(
+            'SELECT COUNT(*) FROM ?:mwl_xlsx_lists WHERE user_id = ?i',
+            $user_id
+        );
+    }
+
+    public function countListsBySessionId(string $session_id): int
+    {
+        return (int) $this->db->getField(
+            'SELECT COUNT(*) FROM ?:mwl_xlsx_lists WHERE session_id = ?s',
+            $session_id
+        );
+    }
+
+    public function countProducts(int $list_id): int
+    {
+        return (int) $this->db->getField(
+            'SELECT COUNT(*) FROM ?:mwl_xlsx_list_products WHERE list_id = ?i',
+            $list_id
+        );
+    }
+
+    public function productExists(int $list_id, int $product_id, string $product_options): bool
+    {
+        return (bool) $this->db->getField(
+            'SELECT 1 FROM ?:mwl_xlsx_list_products WHERE list_id = ?i AND product_id = ?i AND product_options = ?s',
+            $list_id,
+            $product_id,
+            $product_options
+        );
+    }
+
+    public function insertProduct(int $list_id, int $product_id, string $product_options, int $amount): void
+    {
+        $this->db->query('INSERT INTO ?:mwl_xlsx_list_products ?e', [
+            'list_id'         => $list_id,
+            'product_id'      => $product_id,
+            'product_options' => $product_options,
+            'amount'          => $amount,
+            'timestamp'       => TIME,
+        ]);
+    }
+
+    public function deleteProduct(int $list_id, int $product_id): int
+    {
+        return (int) $this->db->query(
+            'DELETE FROM ?:mwl_xlsx_list_products WHERE list_id = ?i AND product_id = ?i',
+            $list_id,
+            $product_id
+        );
+    }
+
+    public function touchList(int $list_id, string $timestamp): void
+    {
+        $this->db->query(
+            'UPDATE ?:mwl_xlsx_lists SET updated_at = ?s WHERE list_id = ?i',
+            $timestamp,
+            $list_id
+        );
+    }
+
+    public function renameList(int $list_id, string $name, string $timestamp): void
+    {
+        $this->db->query(
+            'UPDATE ?:mwl_xlsx_lists SET name = ?s, updated_at = ?s WHERE list_id = ?i',
+            $name,
+            $timestamp,
+            $list_id
+        );
+    }
+
+    public function listBelongsTo(int $list_id, ?int $user_id, ?string $session_id): bool
+    {
+        if ($user_id !== null) {
+            return (bool) $this->db->getField(
+                'SELECT list_id FROM ?:mwl_xlsx_lists WHERE list_id = ?i AND user_id = ?i',
+                $list_id,
+                $user_id
+            );
+        }
+
+        if ($session_id !== null) {
+            return (bool) $this->db->getField(
+                'SELECT list_id FROM ?:mwl_xlsx_lists WHERE list_id = ?i AND session_id = ?s',
+                $list_id,
+                $session_id
+            );
+        }
+
+        return false;
+    }
+
+    public function deleteList(int $list_id): void
+    {
+        $this->db->query('DELETE FROM ?:mwl_xlsx_lists WHERE list_id = ?i', $list_id);
+    }
+
+    public function deleteListProducts(int $list_id): void
+    {
+        $this->db->query('DELETE FROM ?:mwl_xlsx_list_products WHERE list_id = ?i', $list_id);
+    }
+
+    public function getUserSettingsByUserId(int $user_id): ?array
+    {
+        $this->ensureUserSettingsTable();
+
+        $row = $this->db->getRow(
+            'SELECT price_multiplier, price_append, round_to FROM ?:mwl_xlsx_user_settings WHERE user_id = ?i ORDER BY id DESC LIMIT 1',
+            $user_id
+        );
+
+        return $row ?: null;
+    }
+
+    public function getUserSettingsBySessionId(string $session_id): ?array
+    {
+        $this->ensureUserSettingsTable();
+
+        $row = $this->db->getRow(
+            'SELECT price_multiplier, price_append, round_to FROM ?:mwl_xlsx_user_settings WHERE session_id = ?s ORDER BY id DESC LIMIT 1',
+            $session_id
+        );
+
+        return $row ?: null;
+    }
+
+    public function saveUserSettingsForUser(int $user_id, array $data): void
+    {
+        $this->ensureUserSettingsTable();
+
+        $exists = $this->db->getField(
+            'SELECT id FROM ?:mwl_xlsx_user_settings WHERE user_id = ?i ORDER BY id DESC LIMIT 1',
+            $user_id
+        );
+
+        if ($exists) {
+            $this->db->query('UPDATE ?:mwl_xlsx_user_settings SET ?u WHERE id = ?i', $data, (int) $exists);
+
+            return;
+        }
+
+        $this->db->query('INSERT INTO ?:mwl_xlsx_user_settings ?e', $data);
+    }
+
+    public function saveUserSettingsForSession(string $session_id, array $data): void
+    {
+        $this->ensureUserSettingsTable();
+
+        $exists = $this->db->getField(
+            'SELECT id FROM ?:mwl_xlsx_user_settings WHERE session_id = ?s ORDER BY id DESC LIMIT 1',
+            $session_id
+        );
+
+        if ($exists) {
+            $this->db->query('UPDATE ?:mwl_xlsx_user_settings SET ?u WHERE id = ?i', $data, (int) $exists);
+
+            return;
+        }
+
+        $this->db->query('INSERT INTO ?:mwl_xlsx_user_settings ?e', $data);
+    }
+
+    private function ensureUserSettingsTable(): void
+    {
+        if ($this->userSettingsTableEnsured) {
+            return;
+        }
+
+        $this->db->query("CREATE TABLE IF NOT EXISTS `?:mwl_xlsx_user_settings` (
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `user_id` INT UNSIGNED NOT NULL DEFAULT 0,
+            `session_id` VARCHAR(64) NOT NULL DEFAULT '',
+            `price_multiplier` DECIMAL(12,4) NOT NULL DEFAULT '1.0000',
+            `price_append` INT NOT NULL DEFAULT '0',
+            `round_to` INT NOT NULL DEFAULT '10',
+            `updated_at` DATETIME NOT NULL,
+            PRIMARY KEY (`id`),
+            KEY `user_id` (`user_id`),
+            KEY `session_id` (`session_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8");
+
+        $prefix = (string) Registry::get('config.table_prefix');
+        $table = $prefix . 'mwl_xlsx_user_settings';
+
+        $has_round_to = (int) $this->db->getField(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?s AND COLUMN_NAME = 'round_to'",
+            $table
+        );
+
+        if (!$has_round_to) {
+            $this->db->query('ALTER TABLE ?:mwl_xlsx_user_settings ADD COLUMN `round_to` DECIMAL(12,4) NOT NULL DEFAULT 10');
+        }
+
+        $this->userSettingsTableEnsured = true;
+    }
+}

--- a/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/MediaList/ListService.php
+++ b/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/MediaList/ListService.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\MediaList;
+
+use Tygh\Registry;
+use Tygh\Tygh;
+
+class ListService
+{
+    public const STATUS_ADDED = 'added';
+    public const STATUS_EXISTS = 'exists';
+    public const STATUS_LIMIT = 'limit';
+
+    /** @var ListRepository */
+    private $repository;
+
+    /** @var object|null */
+    private $session;
+
+    public function __construct(ListRepository $repository, $session = null)
+    {
+        $this->repository = $repository;
+        $this->session = $session ?: $this->resolveSessionFromContainer();
+    }
+
+    public function getList(int $list_id, array $auth): ?array
+    {
+        if (!empty($auth['user_id'])) {
+            return $this->repository->findByUserId($list_id, (int) $auth['user_id']);
+        }
+
+        $session_id = $this->getSessionId();
+
+        return $session_id === null
+            ? null
+            : $this->repository->findBySessionId($list_id, $session_id);
+    }
+
+    public function getLists(?int $user_id = null, ?string $session_id = null): array
+    {
+        if ($user_id) {
+            return $this->repository->getListsByUserId($user_id);
+        }
+
+        $session_id = $session_id ?: $this->getSessionId();
+
+        if ($session_id === null) {
+            return [];
+        }
+
+        return $this->repository->getListsBySessionId($session_id);
+    }
+
+    public function getMediaListsCount(array $auth): int
+    {
+        if (!empty($auth['user_id'])) {
+            return $this->repository->countListsByUserId((int) $auth['user_id']);
+        }
+
+        $session_id = $this->getSessionId();
+
+        if ($session_id === null) {
+            return 0;
+        }
+
+        return $this->repository->countListsBySessionId($session_id);
+    }
+
+    public function addProduct(int $list_id, int $product_id, array $options = [], int $amount = 1): string
+    {
+        $limit = (int) Registry::get('addons.mwl_xlsx.max_list_items');
+
+        if ($limit > 0 && $this->repository->countProducts($list_id) >= $limit) {
+            return self::STATUS_LIMIT;
+        }
+
+        $serialized = serialize($options);
+
+        if ($this->repository->productExists($list_id, $product_id, $serialized)) {
+            return self::STATUS_EXISTS;
+        }
+
+        $timestamp = $this->now();
+        $this->repository->insertProduct($list_id, $product_id, $serialized, $amount);
+        $this->repository->touchList($list_id, $timestamp);
+
+        return self::STATUS_ADDED;
+    }
+
+    public function removeProduct(int $list_id, int $product_id): bool
+    {
+        $removed = $this->repository->deleteProduct($list_id, $product_id);
+
+        if ($removed) {
+            $this->repository->touchList($list_id, $this->now());
+        }
+
+        return $removed > 0;
+    }
+
+    public function updateListName(int $list_id, string $name, ?int $user_id = null, ?string $session_id = null): bool
+    {
+        if ($name === '') {
+            return false;
+        }
+
+        [$user_id, $session_id] = $this->normalizeIdentity($user_id, $session_id);
+
+        if (!$this->repository->listBelongsTo($list_id, $user_id, $session_id)) {
+            return false;
+        }
+
+        $this->repository->renameList($list_id, $name, $this->now());
+
+        return true;
+    }
+
+    public function deleteList(int $list_id, ?int $user_id = null, ?string $session_id = null): bool
+    {
+        [$user_id, $session_id] = $this->normalizeIdentity($user_id, $session_id);
+
+        if (!$this->repository->listBelongsTo($list_id, $user_id, $session_id)) {
+            return false;
+        }
+
+        $this->repository->deleteListProducts($list_id);
+        $this->repository->deleteList($list_id);
+
+        return true;
+    }
+
+    public function getUserSettings(array $auth): array
+    {
+        if (!empty($auth['user_id'])) {
+            $row = $this->repository->getUserSettingsByUserId((int) $auth['user_id']);
+        } else {
+            $session_id = $this->getSessionId();
+            $row = $session_id === null ? null : $this->repository->getUserSettingsBySessionId($session_id);
+        }
+
+        return [
+            'price_multiplier' => isset($row['price_multiplier']) ? (float) $row['price_multiplier'] : 1.0,
+            'price_append'     => isset($row['price_append']) ? (int) $row['price_append'] : 0,
+            'round_to'         => isset($row['round_to']) ? (int) $row['round_to'] : 10,
+        ];
+    }
+
+    public function saveUserSettings(array $auth, array $data): void
+    {
+        $settings = [
+            'price_multiplier' => isset($data['price_multiplier']) ? (float) $data['price_multiplier'] : 1.0,
+            'price_append'     => isset($data['price_append']) ? (int) $data['price_append'] : 0,
+            'round_to'         => isset($data['round_to']) ? (int) $data['round_to'] : 10,
+            'updated_at'       => $this->now(),
+        ];
+
+        if (!empty($auth['user_id'])) {
+            $this->repository->saveUserSettingsForUser((int) $auth['user_id'], [
+                'user_id'         => (int) $auth['user_id'],
+                'session_id'      => '',
+            ] + $settings);
+
+            return;
+        }
+
+        $session_id = $this->getSessionId();
+
+        if ($session_id === null) {
+            return;
+        }
+
+        $this->repository->saveUserSettingsForSession($session_id, [
+            'user_id'         => 0,
+            'session_id'      => $session_id,
+        ] + $settings);
+    }
+
+    private function normalizeIdentity(?int $user_id, ?string $session_id): array
+    {
+        if ($user_id) {
+            return [$user_id, null];
+        }
+
+        if ($session_id) {
+            return [null, $session_id];
+        }
+
+        return [null, $this->getSessionId()];
+    }
+
+    private function getSessionId(): ?string
+    {
+        $session = $this->session;
+
+        if ($session && method_exists($session, 'getID')) {
+            $id = $session->getID();
+
+            return is_string($id) ? $id : null;
+        }
+
+        $container = Tygh::$app ?? null;
+
+        if ($container instanceof \ArrayAccess && $container->offsetExists('session')) {
+            $session = $container['session'];
+            if ($session && method_exists($session, 'getID')) {
+                $id = $session->getID();
+
+                return is_string($id) ? $id : null;
+            }
+        }
+
+        return null;
+    }
+
+    private function now(): string
+    {
+        return date('Y-m-d H:i:s');
+    }
+
+    private function resolveSessionFromContainer()
+    {
+        $container = Tygh::$app ?? null;
+
+        if ($container instanceof \ArrayAccess && $container->offsetExists('session')) {
+            return $container['session'];
+        }
+
+        return null;
+    }
+}

--- a/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Tests/MediaList/ListExporterTest.php
+++ b/app/addons/mwl_xlsx/Tygh/Addons/MwlXlsx/Tests/MediaList/ListExporterTest.php
@@ -84,13 +84,6 @@ if (!function_exists(__NAMESPACE__ . '\\__')) {
     }
 }
 
-if (!function_exists(__NAMESPACE__ . '\\fn_mwl_xlsx_get_user_settings')) {
-    function fn_mwl_xlsx_get_user_settings(array $auth)
-    {
-        return ListExporterTestState::$userSettings;
-    }
-}
-
 if (!function_exists(__NAMESPACE__ . '\\fn_mwl_xlsx_transform_price_for_export')) {
     function fn_mwl_xlsx_transform_price_for_export($price, array $settings)
     {
@@ -174,6 +167,14 @@ use PHPUnit\Framework\TestCase;
 use Tygh\Addons\MwlXlsx\MediaList\ListExporter;
 use Tygh\Addons\MwlXlsx\MediaList\ListExporterTestState;
 
+class ListServiceStub
+{
+    public function getUserSettings(array $auth): array
+    {
+        return ListExporterTestState::$userSettings;
+    }
+}
+
 class ListExporterTest extends TestCase
 {
     protected function setUp(): void
@@ -232,7 +233,7 @@ class ListExporterTest extends TestCase
         ];
 
         $auth = ['user_id' => 5];
-        $exporter = new ListExporter();
+        $exporter = new ListExporter(null, null, new ListServiceStub());
 
         $products = $exporter->getListProducts(10, $auth, 'en');
         $this->assertCount(2, $products);
@@ -269,7 +270,7 @@ class ListExporterTest extends TestCase
     {
         $sheet_response = new FakeSpreadsheetResponse([['sheetId' => 321]]);
         $sheets = new FakeSheets($sheet_response);
-        $exporter = new ListExporter($sheets);
+        $exporter = new ListExporter($sheets, null, new ListServiceStub());
 
         $data = [
             ['H1', 'H2', 'H3'],

--- a/app/addons/mwl_xlsx/tests/MediaList/ListServiceTest.php
+++ b/app/addons/mwl_xlsx/tests/MediaList/ListServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tygh\Addons\MwlXlsx\Tests\MediaList;
+
+use PHPUnit\Framework\TestCase;
+use Tygh\Addons\MwlXlsx\MediaList\ListRepository;
+use Tygh\Addons\MwlXlsx\MediaList\ListService;
+use Tygh\Registry;
+
+class SessionStub
+{
+    /** @var string */
+    private $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getID(): string
+    {
+        return $this->id;
+    }
+}
+
+class ListServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Registry::set('addons.mwl_xlsx.max_list_items', 0);
+    }
+
+    public function testAddProductStopsAtLimit(): void
+    {
+        Registry::set('addons.mwl_xlsx.max_list_items', 2);
+
+        $repository = $this->createMock(ListRepository::class);
+        $repository->expects($this->once())
+            ->method('countProducts')
+            ->with(15)
+            ->willReturn(2);
+        $repository->expects($this->never())->method('productExists');
+        $repository->expects($this->never())->method('insertProduct');
+        $repository->expects($this->never())->method('touchList');
+
+        $service = new ListService($repository, new SessionStub('sess-1'));
+
+        $status = $service->addProduct(15, 101, ['size' => 'L'], 1);
+
+        $this->assertSame(ListService::STATUS_LIMIT, $status);
+    }
+
+    public function testAddProductDetectsDuplicate(): void
+    {
+        $repository = $this->createMock(ListRepository::class);
+        $repository->expects($this->once())
+            ->method('countProducts')
+            ->with(20)
+            ->willReturn(1);
+        $repository->expects($this->once())
+            ->method('productExists')
+            ->with(20, 55, serialize(['color' => 'red']))
+            ->willReturn(true);
+        $repository->expects($this->never())->method('insertProduct');
+        $repository->expects($this->never())->method('touchList');
+
+        Registry::set('addons.mwl_xlsx.max_list_items', 5);
+        $service = new ListService($repository, new SessionStub('sess-2'));
+
+        $status = $service->addProduct(20, 55, ['color' => 'red'], 1);
+
+        $this->assertSame(ListService::STATUS_EXISTS, $status);
+    }
+
+    public function testAddProductInsertsAndTouchesList(): void
+    {
+        $repository = $this->createMock(ListRepository::class);
+        $repository->expects($this->once())
+            ->method('countProducts')
+            ->with(5)
+            ->willReturn(1);
+        $repository->expects($this->once())
+            ->method('productExists')
+            ->with(5, 300, serialize([]))
+            ->willReturn(false);
+        $repository->expects($this->once())
+            ->method('insertProduct')
+            ->with(5, 300, serialize([]), 2);
+        $repository->expects($this->once())
+            ->method('touchList')
+            ->with(5, $this->callback(function ($timestamp) {
+                return is_string($timestamp) && $timestamp !== '';
+            }));
+
+        Registry::set('addons.mwl_xlsx.max_list_items', 10);
+        $service = new ListService($repository, new SessionStub('sess-3'));
+
+        $status = $service->addProduct(5, 300, [], 2);
+
+        $this->assertSame(ListService::STATUS_ADDED, $status);
+    }
+
+    public function testGetMediaListsCountUsesSession(): void
+    {
+        $repository = $this->createMock(ListRepository::class);
+        $repository->expects($this->once())
+            ->method('countListsBySessionId')
+            ->with('sess-4')
+            ->willReturn(7);
+        $repository->expects($this->never())->method('countListsByUserId');
+
+        $service = new ListService($repository, new SessionStub('sess-4'));
+
+        $this->assertSame(7, $service->getMediaListsCount([]));
+    }
+}

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/buttons_block.post.tpl
@@ -8,10 +8,11 @@
     {assign var=is_price_request value=(fn_mwl_xlsx_can_view_price($auth) && ($runtime.controller == 'products' && $runtime.mode == 'view'))}
     {assign var="view_layout" value=$selected_layout|default:$smarty.request.layout|default:$smarty.cookies.selected_layout|default:$settings.Appearance.default_products_view}
     {if $is_lists}
-        {if $auth}
-            {assign var=lists value=fn_mwl_xlsx_get_lists($auth.user_id)}
+        {assign var=list_service value=fn_mwl_xlsx_list_service()}
+        {if $auth && $auth.user_id}
+            {assign var=lists value=$list_service->getLists($auth.user_id)}
         {else}
-            {assign var=lists value=fn_mwl_xlsx_get_lists(null)}
+            {assign var=lists value=$list_service->getLists(null)}
         {/if}
 
         <div class="mwl_xlsx-control">

--- a/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/product_block.post.tpl
+++ b/var/themes_repository/abt__unitheme2/templates/addons/mwl_xlsx/hooks/products/product_block.post.tpl
@@ -32,10 +32,11 @@
             }(Tygh, Tygh.$));
             </script>
 
-            {if $auth}
-                {assign var=lists value=fn_mwl_xlsx_get_lists($auth.user_id)}
+            {assign var=list_service value=fn_mwl_xlsx_list_service()}
+            {if $auth && $auth.user_id}
+                {assign var=lists value=$list_service->getLists($auth.user_id)}
             {else}
-                {assign var=lists value=fn_mwl_xlsx_get_lists(null)}
+                {assign var=lists value=$list_service->getLists(null)}
             {/if}
             <div class="mwl_xlsx-control mwl_xlsx-control--category">
                 <select class="mwl_xlsx-select" data-ca-list-select-xlsx>


### PR DESCRIPTION
## Summary
- introduce a dedicated media list repository and service to encapsulate list CRUD, settings, and counting logic
- refactor controllers, templates, and the list exporter to consume the new service instead of legacy helpers
- add PHPUnit coverage for key list service behaviours and update existing exporter tests for the new dependency

## Testing
- vendor/bin/phpunit -c app/addons/mwl_xlsx/phpunit.xml.dist *(fails: vendor/bin/phpunit missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2633dd008832ca285f3ce34487f89